### PR TITLE
Fixes when mismatch onload

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 .env
+prod.env
+staging.env
 .git
 .gitignore
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,5 @@ Thumbs.db
 
 # dotenv environment variables file
 .env
-
+prod.env
+staging.env

--- a/src/app/downloads/downloads.component.ts
+++ b/src/app/downloads/downloads.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Subscription } from 'rxjs/Subscription';
 import { CastleService } from '../core';
-import { EpisodeModel, INTERVAL_DAILY, FilterModel } from '../ngrx/model';
+import { EpisodeModel, INTERVAL_DAILY, FilterModel, TWO_WEEKS } from '../ngrx/model';
 import { CastleFilterAction, CastlePodcastMetricsAction, CastleEpisodeMetricsAction } from '../ngrx/actions';
 import { selectFilter, selectEpisodes } from '../ngrx/reducers';
 import { filterAllPodcastEpisodes } from '../shared/util/metrics.util';
@@ -99,6 +99,7 @@ export class DownloadsComponent implements OnInit, OnDestroy {
     const beginDate = beginningOfTodayUTC();
     const beginDateTwoWeeks = beginDate.subtract(beginDate.days() + 7, 'days').toDate();
     this.filter = {
+      when: TWO_WEEKS,
       beginDate: beginDateTwoWeeks, // TWO_WEEKS
       endDate,
       interval: INTERVAL_DAILY

--- a/src/app/ngrx/model/filter.model.ts
+++ b/src/app/ngrx/model/filter.model.ts
@@ -2,11 +2,25 @@ import { PodcastModel } from './podcast.model';
 import { EpisodeModel } from './episode.model';
 import { IntervalModel } from './metrics.model';
 
+export const TODAY = 'Today';
+export const THIS_WEEK = 'This week';
+export const TWO_WEEKS = '2 weeks';
+export const THIS_MONTH = 'This month';
+export const THREE_MONTHS = '3 months';
+export const THIS_YEAR = 'This year';
+export const YESTERDAY = 'Yesterday';
+export const LAST_WEEK = 'Last week';
+export const PRIOR_TWO_WEEKS = 'Prior 2 weeks';
+export const LAST_MONTH = 'Last month';
+export const PRIOR_THREE_MONTHS = 'Prior 3 months';
+export const LAST_YEAR = 'Last year';
+
 // TODO: filter doesn't yet support type (like downloads on the metrics model)
 // --> will a filter apply just to downloads and not be the same if they move to geo data? or would users not want that to stick?
 export interface FilterModel {
   podcast?: PodcastModel;
   episodes?: EpisodeModel[];
+  when?: string;
   beginDate?: Date;
   endDate?: Date;
   interval?: IntervalModel;

--- a/src/app/ngrx/model/index.ts
+++ b/src/app/ngrx/model/index.ts
@@ -2,4 +2,5 @@ export { PodcastModel } from './podcast.model';
 export { EpisodeModel } from './episode.model';
 export { INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN, IntervalModel,
   PodcastMetricsModel, EpisodeMetricsModel, MetricsType } from './metrics.model';
-export { FilterModel } from './filter.model';
+export { FilterModel, TODAY, THIS_WEEK, TWO_WEEKS, THIS_MONTH, THREE_MONTHS, THIS_YEAR,
+  YESTERDAY, LAST_WEEK, PRIOR_TWO_WEEKS, LAST_MONTH, PRIOR_THREE_MONTHS, LAST_YEAR } from './filter.model';

--- a/src/app/ngrx/reducers/filter.reducer.spec.ts
+++ b/src/app/ngrx/reducers/filter.reducer.spec.ts
@@ -1,6 +1,8 @@
 import { CastleFilterAction } from '../actions';
 import { INTERVAL_DAILY, INTERVAL_HOURLY } from '../model';
 import { FilterReducer } from './filter.reducer';
+import { beginningOfTodayUTC, endOfTodayUTC } from '../../shared/util/date.util';
+import { TODAY } from '../model';
 
 describe('FilterReducer', () => {
   let newState;
@@ -48,6 +50,15 @@ describe('FilterReducer', () => {
     newState = FilterReducer(newState,
       new CastleFilterAction({filter: {beginDate: new Date('2017-08-26T10:00:00Z'), endDate: new Date('2017-09-10T12:00:00Z')}}));
     expect(newState.beginDate.getDate()).toEqual(26);
+  });
+
+  it('should update when value if begin or end dates are present', () => {
+    newState = FilterReducer(newState,
+      new CastleFilterAction({filter: {when: TODAY, beginDate: beginningOfTodayUTC().toDate(), endDate: endOfTodayUTC().toDate()}}));
+    expect(newState.when).toEqual(TODAY);
+    newState = FilterReducer(newState,
+      new CastleFilterAction({filter: {beginDate: beginningOfTodayUTC().subtract(1, 'days').toDate()}}));
+    expect(newState.when).toBeUndefined();
   });
 
   it ('should update with new interval', () => {

--- a/src/app/ngrx/reducers/filter.reducer.ts
+++ b/src/app/ngrx/reducers/filter.reducer.ts
@@ -13,6 +13,13 @@ export function FilterReducer(state: FilterModel = initialState, action: ActionW
       if (action.payload.filter.episodes) {
         newState.episodes = [...action.payload.filter.episodes];
       }
+      if (action.payload.filter.beginDate || action.payload.filter.endDate) {
+        // when can only be set with accompanying begin or end date
+        // when can be set to undefined if begin or end date is present but when is not
+        // (we can't generate dates in here, that would be non deterministic,
+        // but we can and maybe should do it in action creators instead of components)
+        newState.when = action.payload.filter.when;
+      }
       if (action.payload.filter.beginDate) {
         newState.beginDate = action.payload.filter.beginDate;
       }

--- a/src/app/shared/filter/canned-range.component.spec.ts
+++ b/src/app/shared/filter/canned-range.component.spec.ts
@@ -4,11 +4,12 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
 
 import { DatepickerModule, SelectModule } from 'ngx-prx-styleguide';
-import { CannedRangeComponent, TODAY, THIS_WEEK, TWO_WEEKS, THIS_MONTH, THREE_MONTHS, THIS_YEAR,
-  YESTERDAY, LAST_WEEK, PRIOR_TWO_WEEKS, LAST_MONTH, PRIOR_THREE_MONTHS, LAST_YEAR } from './canned-range.component';
+import { CannedRangeComponent } from './canned-range.component';
 
 import { reducers } from '../../ngrx/reducers';
-import { FilterModel, INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN } from '../../ngrx/model';
+import { FilterModel, INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN,
+  TODAY, THIS_WEEK, TWO_WEEKS, THIS_MONTH, THREE_MONTHS, THIS_YEAR,
+  YESTERDAY, LAST_WEEK, PRIOR_TWO_WEEKS, LAST_MONTH, PRIOR_THREE_MONTHS, LAST_YEAR} from '../../ngrx/model';
 import { CastleFilterAction } from '../../ngrx/actions';
 
 import { beginningOfTodayUTC, endOfTodayUTC } from '../util/date.util';
@@ -43,6 +44,7 @@ describe('CannedRangeComponent', () => {
 
   it('should set selected if filter is one of the canned ranges', () => {
     filter = {
+      when: TODAY,
       beginDate: beginningOfTodayUTC().toDate(), // 'Today'
       endDate: endOfTodayUTC().toDate(),
       interval: INTERVAL_DAILY
@@ -53,6 +55,7 @@ describe('CannedRangeComponent', () => {
 
   it('should disable NEXT button if the end date would be past the end of the currently selected period', () => {
     filter = {
+      when: TODAY,
       beginDate: beginningOfTodayUTC().toDate(), // 'Today'
       endDate: endOfTodayUTC().toDate(),
       interval: INTERVAL_DAILY
@@ -69,12 +72,13 @@ describe('CannedRangeComponent', () => {
       interval: INTERVAL_DAILY
     };
     comp.store.dispatch(new CastleFilterAction({filter}));
-    expect(comp.lastChosenRange).toBe(undefined);
+    expect(comp.lastChosenRange).toBeNull();
     expect(comp.prevDisabled).toEqual('disabled');
   });
 
   it('should go to next range when NEXT button is clicked', () => {
     filter = {
+      when: YESTERDAY,
       beginDate: beginningOfTodayUTC().subtract(1, 'days').toDate(), // 'Yesterday'
       endDate: endOfTodayUTC().subtract(1, 'days').toDate(),
       interval: INTERVAL_DAILY
@@ -88,8 +92,8 @@ describe('CannedRangeComponent', () => {
   });
 
   it('should go to prev range when PREV button is click', () => {
-    comp.lastChosenRange = [1, 'weeks']; // get it to believe something was selected from the drop down
     filter = {
+      when: THIS_WEEK,
       beginDate: beginningOfTodayUTC().subtract(beginningOfTodayUTC().day(), 'days').toDate(), // 'This week'
       endDate: endOfTodayUTC().toDate(),
       interval: INTERVAL_DAILY
@@ -106,6 +110,7 @@ describe('CannedRangeComponent', () => {
   it('TWO_WEEKS option should be two weeks starting on Sunday of last week not extending past today', () => {
     // component needs a default filter in order to initialize options
     filter = {
+      when: TWO_WEEKS,
       beginDate: beginningOfTodayUTC().toDate(), // 'Today'
       endDate: endOfTodayUTC().toDate(),
       interval: INTERVAL_DAILY
@@ -120,6 +125,7 @@ describe('CannedRangeComponent', () => {
   it('THIS_MONTH option should begin on the 1st of this month not extending past today', () => {
     // component needs a default filter in order to initialize options
     filter = {
+      when: THIS_MONTH,
       beginDate: beginningOfTodayUTC().toDate(), // 'Today'
       endDate: endOfTodayUTC().toDate(),
       interval: INTERVAL_DAILY
@@ -133,6 +139,7 @@ describe('CannedRangeComponent', () => {
   it('THREE_MONTHS option should begin on the 1st of the month 3 months ago not extending past today', () => {
     // component needs a default filter in order to initialize options
     filter = {
+      when: TODAY,
       beginDate: beginningOfTodayUTC().toDate(), // 'Today'
       endDate: endOfTodayUTC().toDate(),
       interval: INTERVAL_DAILY
@@ -145,6 +152,7 @@ describe('CannedRangeComponent', () => {
 
   it('when NEXTing from LAST_YEAR, should go to THIS_YEAR and not extend past today', () => {
     filter = {
+      when: LAST_YEAR,
       beginDate: beginningOfTodayUTC().month(0).date(1).subtract(1, 'years').toDate(), // 'LAST_YEAR'
       endDate: endOfTodayUTC().month(11).date(31).subtract(1, 'years').toDate(),
       interval: INTERVAL_DAILY
@@ -157,9 +165,9 @@ describe('CannedRangeComponent', () => {
   });
 
   it('when NEXTing from PRIOR_TWO_WEEKS, should go to TWO_WEEKS and not extend past today', () => {
-    comp.lastChosenRange = [2, 'weeks']; // get it to believe something was selected from the drop down
     const daysIntoWeek = beginningOfTodayUTC().day();
     filter = {
+      when: PRIOR_TWO_WEEKS,
       beginDate: beginningOfTodayUTC().subtract(daysIntoWeek + 21, 'days').toDate(), // 'PRIOR_TWO_WEEKS'
       endDate: endOfTodayUTC().subtract(daysIntoWeek + 8, 'days').toDate(),
       interval: INTERVAL_DAILY
@@ -173,6 +181,7 @@ describe('CannedRangeComponent', () => {
 
   it('when PREVing from THIS_MONTH, should go to LAST_MONTH', () => {
     filter = {
+      when: THIS_MONTH,
       beginDate: beginningOfTodayUTC().date(1).toDate(), // 'THIS_MONTH'
       endDate: endOfTodayUTC().toDate(),
       interval: INTERVAL_DAILY
@@ -187,6 +196,7 @@ describe('CannedRangeComponent', () => {
 
   it('when PREVing from THREE_MONTHS, should go to PRIOR_THREE_MONTHS', () => {
     filter = {
+      when: THREE_MONTHS,
       beginDate: beginningOfTodayUTC().subtract(2, 'months').date(1).toDate(), // 'THREE_MONTHS'
       endDate: endOfTodayUTC().toDate(),
       interval: INTERVAL_DAILY
@@ -201,6 +211,7 @@ describe('CannedRangeComponent', () => {
 
   it('should not have options more than 10 days apart when interval is 15 minutes', () => {
     filter = {
+      when: TODAY,
       beginDate: beginningOfTodayUTC().toDate(), // 'TODAY'
       endDate: endOfTodayUTC().toDate(),
       interval: INTERVAL_15MIN
@@ -215,6 +226,7 @@ describe('CannedRangeComponent', () => {
 
   it('should not have options more than 40 days apart when interval is hourly', () => {
     filter = {
+      when: TODAY,
       beginDate: beginningOfTodayUTC().toDate(), // 'TODAY'
       endDate: endOfTodayUTC().toDate(),
       interval: INTERVAL_HOURLY

--- a/src/app/shared/filter/canned-range.component.ts
+++ b/src/app/shared/filter/canned-range.component.ts
@@ -146,6 +146,10 @@ export class CannedRangeComponent implements OnInit, OnDestroy {
       !misMatchedNamedRanges) {
       this.selected = range;
       this.setLastChosenRange(when);
+      // keep state in sync
+      if (!this.filter.when) {
+        this.store.dispatch(new CastleFilterAction({filter: {when, beginDate, endDate}}));
+      }
     }
   }
 

--- a/src/app/shared/filter/canned-range.component.ts
+++ b/src/app/shared/filter/canned-range.component.ts
@@ -1,23 +1,12 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Subscription } from 'rxjs/Subscription';
-import { FilterModel, INTERVAL_15MIN, INTERVAL_HOURLY, INTERVAL_DAILY } from '../../ngrx/model';
+import { FilterModel, INTERVAL_15MIN, INTERVAL_HOURLY, INTERVAL_DAILY,
+  TODAY, THIS_WEEK, TWO_WEEKS, THIS_MONTH, THREE_MONTHS, THIS_YEAR,
+  YESTERDAY, LAST_WEEK, PRIOR_TWO_WEEKS, LAST_MONTH, PRIOR_THREE_MONTHS, LAST_YEAR } from '../../ngrx/model';
 import { CastleFilterAction } from '../../ngrx/actions';
 import { isMoreThanXDays, beginningOfTodayUTC, endOfTodayUTC } from '../util/date.util';
 import * as moment from 'moment';
-
-export const TODAY = 'Today';
-export const THIS_WEEK = 'This week';
-export const TWO_WEEKS = '2 weeks';
-export const THIS_MONTH = 'This month';
-export const THREE_MONTHS = '3 months';
-export const THIS_YEAR = 'This year';
-export const YESTERDAY = 'Yesterday';
-export const LAST_WEEK = 'Last week';
-export const PRIOR_TWO_WEEKS = 'Prior 2 weeks';
-export const LAST_MONTH = 'Last month';
-export const PRIOR_THREE_MONTHS = 'Prior 3 months';
-export const LAST_YEAR = 'Last year';
 
 @Component({
   selector: 'metrics-canned-range',
@@ -56,57 +45,62 @@ export class CannedRangeComponent implements OnInit, OnDestroy {
   genWhenDates() {
     this.selected = null;
 
+    if (!this.filter.when) {
+      // clear out last chosen range if user used the date pickers
+      this.lastChosenRange = null;
+    }
+
     let utcEndDate = endOfTodayUTC();
     let utcBeginDate = beginningOfTodayUTC();
     const daysIntoWeek = utcEndDate.day();
 
-    this.whenOptions = [[TODAY, {range: [1, 'days'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]];
+    this.whenOptions = [[TODAY, {when: TODAY, beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]];
 
     utcBeginDate.subtract(daysIntoWeek, 'days');
-    this.whenOptions.push([THIS_WEEK, {range: [1, 'weeks'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
+    this.whenOptions.push([THIS_WEEK, {when: THIS_WEEK, beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
 
     utcBeginDate.subtract(7, 'days');
     if (this.filter.interval !== INTERVAL_15MIN ||
       (this.filter.interval === INTERVAL_15MIN && !isMoreThanXDays(10, utcBeginDate, utcEndDate))) {
-      this.whenOptions.push([TWO_WEEKS, {range: [2, 'weeks'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
+      this.whenOptions.push([TWO_WEEKS, {when: TWO_WEEKS, beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
     }
 
     utcBeginDate = beginningOfTodayUTC().date(1);
     if (this.filter.interval !== INTERVAL_15MIN ||
       (this.filter.interval === INTERVAL_15MIN && !isMoreThanXDays(10, utcBeginDate, utcEndDate))) {
-      this.whenOptions.push([THIS_MONTH, {range: [1, 'months'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
+      this.whenOptions.push([THIS_MONTH, {when: THIS_MONTH, beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
     }
 
     utcBeginDate.subtract(2, 'months');
     if (this.filter.interval === INTERVAL_DAILY ||
       (this.filter.interval === INTERVAL_15MIN && !isMoreThanXDays(10, utcBeginDate, utcEndDate)) ||
       (this.filter.interval === INTERVAL_HOURLY && !isMoreThanXDays(40, utcBeginDate, utcEndDate))) {
-      this.whenOptions.push([THREE_MONTHS, {range: [3, 'months'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
+      this.whenOptions.push([THREE_MONTHS, {when: THREE_MONTHS, beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
     }
 
     utcBeginDate = beginningOfTodayUTC().month(0).date(1);
     if (this.filter.interval === INTERVAL_DAILY ||
       (this.filter.interval === INTERVAL_15MIN && !isMoreThanXDays(10, utcBeginDate, utcEndDate)) ||
       (this.filter.interval === INTERVAL_HOURLY && !isMoreThanXDays(40, utcBeginDate, utcEndDate))) {
-      this.whenOptions.push([THIS_YEAR, {range: [1, 'year'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
+      this.whenOptions.push([THIS_YEAR, {when: THIS_YEAR, beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
     }
 
     utcEndDate.subtract(1, 'days');
     utcBeginDate = beginningOfTodayUTC().subtract(1, 'days');
-    this.whenOptions.push([YESTERDAY, {range: [1, 'days'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
+    this.whenOptions.push([YESTERDAY, {when: YESTERDAY, beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
 
     utcEndDate = endOfTodayUTC().subtract(daysIntoWeek + 1, 'days');
     utcBeginDate = beginningOfTodayUTC().subtract(daysIntoWeek + 7, 'days');
-    this.whenOptions.push([LAST_WEEK, {range: [1, 'weeks'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
+    this.whenOptions.push([LAST_WEEK, {when: LAST_WEEK, beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
 
     if (this.filter.interval !== INTERVAL_15MIN) {
       utcEndDate = endOfTodayUTC().subtract(daysIntoWeek + 8, 'days');
       utcBeginDate = beginningOfTodayUTC().subtract(daysIntoWeek + 21, 'days');
-      this.whenOptions.push([PRIOR_TWO_WEEKS, {range: [2, 'weeks'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
+      this.whenOptions.push([PRIOR_TWO_WEEKS, {when: PRIOR_TWO_WEEKS, beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
 
       utcEndDate = endOfTodayUTC().date(1).subtract(1, 'days'); // 1st of month - 1 day
       utcBeginDate = beginningOfTodayUTC().date(1).subtract(1, 'months'); // 1st of month - 1 month
-      this.whenOptions.push([LAST_MONTH, {range: [1, 'months'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
+      this.whenOptions.push([LAST_MONTH, {when: LAST_MONTH, beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
     }
 
     if (this.filter.interval !== INTERVAL_15MIN && this.filter.interval !== INTERVAL_HOURLY) {
@@ -114,13 +108,14 @@ export class CannedRangeComponent implements OnInit, OnDestroy {
       utcEndDate = endOfTodayUTC().date(1).subtract(2, 'months').subtract(1, 'days');
       // first of this month - 5 months
       utcBeginDate = beginningOfTodayUTC().date(1).subtract(5, 'months');
-      this.whenOptions.push([PRIOR_THREE_MONTHS, {range: [3, 'months'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
+      this.whenOptions.push([PRIOR_THREE_MONTHS, {when: PRIOR_THREE_MONTHS,
+        beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
 
       // last day of year minus 1 year
       utcEndDate = endOfTodayUTC().month(11).date(31).subtract(1, 'years');
       // first day of year minus 1 year
       utcBeginDate = beginningOfTodayUTC().month(0).date(1).subtract(1, 'years');
-      this.whenOptions.push([LAST_YEAR, {range: [1, 'year'], beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
+      this.whenOptions.push([LAST_YEAR, {when: LAST_YEAR, beginDate: utcBeginDate.toDate(), endDate: utcEndDate.toDate()}]);
     }
 
     // We don't have back data yet, but users want an All time option,
@@ -135,28 +130,61 @@ export class CannedRangeComponent implements OnInit, OnDestroy {
   }
 
   setSelectedIfFilterIsRange(range) {
-    const namedRange = range[0];
+    const { when, beginDate, endDate } = range[1];
     // if the 1st of the month or 1st of the year is on a Sunday or it's January and the user selected THIS_YEAR,
     // the dates might match but that's not what the user selected
     const misMatchedNamedRanges = this.lastChosenRange &&
-      (this.lastChosenRange[1].indexOf('week') !== -1 && namedRange.indexOf('month') !== -1 ||
-      this.lastChosenRange[1].indexOf('week') !== -1 && namedRange.indexOf('year') !== -1 ||
-      this.lastChosenRange[1].indexOf('month') !== -1 && namedRange.indexOf('week') !== -1 ||
-      this.lastChosenRange[1].indexOf('month') !== -1 && namedRange.indexOf('year') !== -1);
-    const { beginDate, endDate } = range[1];
+      (this.lastChosenRange[1].indexOf('week') !== -1 && when.indexOf('month') !== -1 ||
+      this.lastChosenRange[1].indexOf('week') !== -1 && when.indexOf('year') !== -1 ||
+      this.lastChosenRange[1].indexOf('month') !== -1 && when.indexOf('week') !== -1 ||
+      this.lastChosenRange[1].indexOf('month') !== -1 && when.indexOf('year') !== -1);
+
     if (this.filter.beginDate && this.filter.endDate &&
       this.filter.beginDate.valueOf() === beginDate.valueOf() &&
       this.filter.endDate.valueOf() === endDate.valueOf() &&
+      (!this.filter.when || this.filter.when === when) &&
       !misMatchedNamedRanges) {
       this.selected = range;
+      this.setLastChosenRange(when);
     }
   }
 
   onWhenChange(val) {
-    if (val && val.range && val.beginDate && val.endDate) {
-      this.lastChosenRange = val.range;
-      const { beginDate, endDate } = val;
-      this.store.dispatch(new CastleFilterAction({filter: {beginDate, endDate}}));
+    if (val && val.when && val.beginDate && val.endDate) {
+      const { when, beginDate, endDate } = val;
+      this.setLastChosenRange(when);
+      this.store.dispatch(new CastleFilterAction({filter: {when, beginDate, endDate}}));
+    }
+  }
+
+  setLastChosenRange(when: string) {
+    switch (when) {
+      case TODAY:
+      case YESTERDAY:
+        this.lastChosenRange = [1, 'days'];
+        break;
+      case THIS_WEEK:
+      case LAST_WEEK:
+        this.lastChosenRange = [1, 'weeks'];
+        break;
+      case TWO_WEEKS:
+      case PRIOR_TWO_WEEKS:
+        this.lastChosenRange = [2, 'weeks'];
+        break;
+      case THIS_MONTH:
+      case LAST_MONTH:
+        this.lastChosenRange = [1, 'months'];
+        break;
+      case THREE_MONTHS:
+      case PRIOR_THREE_MONTHS:
+        this.lastChosenRange = [3, 'months'];
+        break;
+      case THIS_YEAR:
+      case LAST_YEAR:
+        this.lastChosenRange = [1, 'years'];
+        break;
+      default:
+        break;
     }
   }
 
@@ -181,16 +209,18 @@ export class CannedRangeComponent implements OnInit, OnDestroy {
   }
 
   prev() {
-    let newBeginDate, newEndDate;
+    let when, newBeginDate, newEndDate;
     if (this.selected) {
       const { beginDate, endDate } = this.selected[1];
       switch (this.selected[0]) {
         case TODAY:
+          when = YESTERDAY;
         case YESTERDAY:
           newBeginDate = moment(beginDate.valueOf()).utc().subtract(1, 'days');
           newEndDate = moment(endDate.valueOf()).utc().subtract(1, 'days');
           break;
         case THIS_WEEK:
+          when = LAST_WEEK;
           newBeginDate = moment(beginDate.valueOf()).utc().subtract(1, 'weeks');
           newEndDate = moment().utc();
           newEndDate.subtract(newEndDate.days() + 1, 'days').hours(23).minutes(59).seconds(59).milliseconds(999);
@@ -200,6 +230,7 @@ export class CannedRangeComponent implements OnInit, OnDestroy {
           newEndDate = moment(endDate.valueOf()).utc().subtract(1, 'weeks');
           break;
         case TWO_WEEKS:
+          when = PRIOR_TWO_WEEKS;
           newBeginDate = moment(beginDate.valueOf()).utc().subtract(2, 'weeks');
           newEndDate = moment().utc();
           newEndDate.subtract(newEndDate.days() + 8, 'days').hours(23).minutes(59).seconds(59).milliseconds(999);
@@ -209,6 +240,7 @@ export class CannedRangeComponent implements OnInit, OnDestroy {
           newEndDate = moment(endDate.valueOf()).utc().subtract(2, 'weeks');
           break;
         case THIS_MONTH:
+          when = LAST_MONTH;
           newBeginDate = moment(beginDate.valueOf()).utc().subtract(1, 'months');
           newEndDate = moment().utc().date(1).hours(23).minutes(59).seconds(59).milliseconds(999).subtract(1, 'days');
           break;
@@ -217,6 +249,7 @@ export class CannedRangeComponent implements OnInit, OnDestroy {
           newEndDate = moment(endDate.valueOf()).utc().subtract(1, 'months');
           break;
         case THREE_MONTHS:
+          when = PRIOR_THREE_MONTHS;
           // first of this month - 5 months
           newBeginDate = moment().utc().date(1).hours(0).minutes(0).seconds(0).milliseconds(0).subtract(5, 'months');
           // first of this month - 1 day and 2 months
@@ -227,6 +260,7 @@ export class CannedRangeComponent implements OnInit, OnDestroy {
           newEndDate = moment(endDate.valueOf()).utc().subtract(3, 'months');
           break;
         case THIS_YEAR:
+          when = LAST_YEAR;
           newBeginDate = moment(beginDate.valueOf()).utc().subtract(1, 'year');
           newEndDate = moment().utc().month(11).date(31).hours(23).minutes(59).seconds(59).milliseconds(999).subtract(1, 'years');
           break;
@@ -242,48 +276,54 @@ export class CannedRangeComponent implements OnInit, OnDestroy {
       newEndDate = moment(this.filter.endDate).utc().subtract(this.lastChosenRange[0], this.lastChosenRange[1]);
     }
     if (newBeginDate && newEndDate) {
-      this.store.dispatch(new CastleFilterAction({filter: {beginDate: newBeginDate.toDate(), endDate: newEndDate.toDate()}}));
+      this.store.dispatch(new CastleFilterAction({filter: {when, beginDate: newBeginDate.toDate(), endDate: newEndDate.toDate()}}));
     }
   }
 
   next() {
-    let newBeginDate, newEndDate;
+    let when, newBeginDate, newEndDate;
     if (this.selected) {
       const { beginDate, endDate } = this.selected[1];
       switch (this.selected[0]) {
         case TODAY:
           break;
         case YESTERDAY:
+          when = TODAY;
           newBeginDate = moment(beginDate.valueOf()).utc().add(1, 'days');
           newEndDate = moment.min(moment(endDate.valueOf()).utc().add(1, 'days'), endOfTodayUTC());
           break;
         case THIS_WEEK:
           break;
         case LAST_WEEK:
+          when = THIS_WEEK;
           newBeginDate = moment(beginDate.valueOf()).utc().add(1, 'weeks');
           newEndDate = moment.min(moment(endDate.valueOf()).utc().add(1, 'weeks'), endOfTodayUTC());
           break;
         case TWO_WEEKS:
           break;
         case PRIOR_TWO_WEEKS:
+          when = TWO_WEEKS;
           newBeginDate = moment(beginDate.valueOf()).utc().add(2, 'weeks');
           newEndDate = moment.min(moment(endDate.valueOf()).utc().add(2, 'weeks'), endOfTodayUTC());
           break;
         case THIS_MONTH:
           break;
         case LAST_MONTH:
+          when = THIS_MONTH;
           newBeginDate = moment(beginDate.valueOf()).utc().add(1, 'months');
           newEndDate = moment.min(moment(endDate.valueOf()).utc().add(1, 'months'), endOfTodayUTC());
           break;
         case THREE_MONTHS:
           break;
         case PRIOR_THREE_MONTHS:
+          when = THREE_MONTHS;
           newBeginDate = moment(beginDate.valueOf()).utc().add(3, 'months');
           newEndDate = moment.min(moment(endDate.valueOf()).utc().add(3, 'months'), endOfTodayUTC());
           break;
         case THIS_YEAR:
           break;
         case LAST_YEAR:
+          when = THIS_YEAR;
           newBeginDate = moment(beginDate.valueOf()).utc().add(1, 'year');
           newEndDate = moment.min(moment(endDate.valueOf()).utc().add(1, 'year'), endOfTodayUTC());
           break;
@@ -295,7 +335,7 @@ export class CannedRangeComponent implements OnInit, OnDestroy {
       newEndDate = moment(this.filter.endDate).utc().add(this.lastChosenRange[0], this.lastChosenRange[1]);
     }
     if (newBeginDate && newEndDate) {
-      this.store.dispatch(new CastleFilterAction({filter: {beginDate: newBeginDate.toDate(), endDate: newEndDate.toDate()}}));
+      this.store.dispatch(new CastleFilterAction({filter: {when, beginDate: newBeginDate.toDate(), endDate: newEndDate.toDate()}}));
     }
   }
 }


### PR DESCRIPTION
When the user first loads metrics, the 2 weeks option should be selected. It is overridden by the This month option currently because the actual dates match.