### PR TITLE
add support for weekly and monthly intervals

### DIFF
--- a/src/app/downloads/downloads-chart.component.spec.ts
+++ b/src/app/downloads/downloads-chart.component.spec.ts
@@ -153,4 +153,14 @@ describe('DownloadsChartComponent', () => {
     };
     expect(getTotal(comp.episodeChartData[0].data)).toBeGreaterThanOrEqual(getTotal(comp.episodeChartData[1].data));
   });
+
+  it('should show bar chart if there are less than 4 data points; otherwise, area', () => {
+    expect(comp.chartType).toEqual('area');
+    comp.store.dispatch(new CastleFilterAction({filter: {
+      beginDate: new Date('2017-09-05T00:00:00Z'),
+      endDate: new Date('2017-09-07T00:00:00Z')
+    }}));
+    fix.detectChanges();
+    expect(comp.chartType).toEqual('bar');
+  });
 });

--- a/src/app/downloads/downloads-chart.component.ts
+++ b/src/app/downloads/downloads-chart.component.ts
@@ -6,9 +6,8 @@ import { EpisodeMetricsModel, PodcastMetricsModel, EpisodeModel, FilterModel,
   INTERVAL_MONTHLY, INTERVAL_WEEKLY, INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN } from '../ngrx/model';
 import { selectFilter, selectPodcastMetrics, selectEpisodeMetrics } from '../ngrx/reducers';
 import { findPodcastMetrics, filterEpisodeMetrics, metricsData, getTotal } from '../shared/util/metrics.util';
-import { mapMetricsToTimeseriesData, subtractTimeseriesDatasets,
-  UTCDateFormat, monthYearFormat, dayMonthDateFormat, dailyDateFormat, hourlyDateFormat,
-  neutralColor, generateShades } from '../shared/util/chart.util';
+import { mapMetricsToTimeseriesData, subtractTimeseriesDatasets, neutralColor, generateShades } from '../shared/util/chart.util';
+import { UTCDateFormat, monthYearFormat, dayMonthDateFormat, dailyDateFormat, hourlyDateFormat } from '../shared/util/date.util';
 
 @Component({
   selector: 'metrics-downloads-chart',

--- a/src/app/downloads/downloads-chart.component.ts
+++ b/src/app/downloads/downloads-chart.component.ts
@@ -3,11 +3,12 @@ import { Store } from '@ngrx/store';
 import { Subscription } from 'rxjs/Subscription';
 import { TimeseriesChartModel } from 'ngx-prx-styleguide';
 import { EpisodeMetricsModel, PodcastMetricsModel, EpisodeModel, FilterModel,
-  INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN } from '../ngrx/model';
+  INTERVAL_MONTHLY, INTERVAL_WEEKLY, INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN } from '../ngrx/model';
 import { selectFilter, selectPodcastMetrics, selectEpisodeMetrics } from '../ngrx/reducers';
 import { findPodcastMetrics, filterEpisodeMetrics, metricsData, getTotal } from '../shared/util/metrics.util';
 import { mapMetricsToTimeseriesData, subtractTimeseriesDatasets,
-  UTCDateFormat, dailyDateFormat, hourlyDateFormat, neutralColor, generateShades } from '../shared/util/chart.util';
+  UTCDateFormat, monthYearFormat, dayMonthDateFormat, dailyDateFormat, hourlyDateFormat,
+  neutralColor, generateShades } from '../shared/util/chart.util';
 
 @Component({
   selector: 'metrics-downloads-chart',
@@ -112,12 +113,16 @@ export class DownloadsChartComponent implements OnDestroy {
   }
 
   dateFormat(): Function {
-    if (this.filter && this.filter.interval) {
-      switch (this.filter.interval.key) {
-        case INTERVAL_DAILY.key:
+    if (this.filter) {
+      switch (this.filter.interval) {
+        case INTERVAL_MONTHLY:
+          return monthYearFormat;
+        case INTERVAL_WEEKLY:
+          return dayMonthDateFormat;
+        case INTERVAL_DAILY:
           return dailyDateFormat;
-        case INTERVAL_HOURLY.key:
-        case INTERVAL_15MIN.key:
+        case INTERVAL_HOURLY:
+        case INTERVAL_15MIN:
           return hourlyDateFormat;
         default:
           return UTCDateFormat;

--- a/src/app/downloads/downloads-chart.component.ts
+++ b/src/app/downloads/downloads-chart.component.ts
@@ -13,7 +13,7 @@ import { mapMetricsToTimeseriesData, subtractTimeseriesDatasets,
 @Component({
   selector: 'metrics-downloads-chart',
   template: `
-    <prx-timeseries-chart *ngIf="chartData" type="area" stacked="true" [datasets]="chartData" [formatX]="dateFormat()">
+    <prx-timeseries-chart *ngIf="chartData" [type]="chartType" stacked="true" [datasets]="chartData" [formatX]="dateFormat()">
     </prx-timeseries-chart>
   `
 })
@@ -129,6 +129,14 @@ export class DownloadsChartComponent implements OnDestroy {
       }
     } else {
       return UTCDateFormat;
+    }
+  }
+
+  get chartType(): string {
+    if (this.chartData && this.chartData.length && this.chartData[0].data.length < 4) {
+      return 'bar';
+    } else {
+      return 'area';
     }
   }
 }

--- a/src/app/downloads/downloads-table.component.ts
+++ b/src/app/downloads/downloads-table.component.ts
@@ -5,7 +5,8 @@ import { EpisodeMetricsModel, EpisodeModel, FilterModel, PodcastMetricsModel,
   INTERVAL_MONTHLY, INTERVAL_WEEKLY, INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN } from '../ngrx/model';
 import { selectEpisodes, selectFilter, selectEpisodeMetrics, selectPodcastMetrics } from '../ngrx/reducers';
 import { findPodcastMetrics, filterAllPodcastEpisodes, filterEpisodeMetrics, metricsData, getTotal } from '../shared/util/metrics.util';
-import { mapMetricsToTimeseriesData, monthYearFormat, dayMonthDateFormat, hourlyDateFormat, monthDateYearFormat } from '../shared/util/chart.util';
+import { mapMetricsToTimeseriesData } from '../shared/util/chart.util';
+import { monthYearFormat, dayMonthDateFormat, hourlyDateFormat, monthDateYearFormat } from '../shared/util/date.util';
 import * as moment from 'moment';
 
 @Component({

--- a/src/app/downloads/downloads-table.component.ts
+++ b/src/app/downloads/downloads-table.component.ts
@@ -2,10 +2,10 @@ import { Component, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Subscription } from 'rxjs/Subscription';
 import { EpisodeMetricsModel, EpisodeModel, FilterModel, PodcastMetricsModel,
-  INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN } from '../ngrx/model';
+  INTERVAL_MONTHLY, INTERVAL_WEEKLY, INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN } from '../ngrx/model';
 import { selectEpisodes, selectFilter, selectEpisodeMetrics, selectPodcastMetrics } from '../ngrx/reducers';
 import { findPodcastMetrics, filterAllPodcastEpisodes, filterEpisodeMetrics, metricsData, getTotal } from '../shared/util/metrics.util';
-import { mapMetricsToTimeseriesData, dayMonthDate, hourlyDateFormat } from '../shared/util/chart.util';
+import { mapMetricsToTimeseriesData, monthYearFormat, dayMonthDateFormat, hourlyDateFormat, monthDateYearFormat } from '../shared/util/chart.util';
 import * as moment from 'moment';
 
 @Component({
@@ -125,7 +125,7 @@ export class DownloadsTableComponent implements OnDestroy {
             return {
               title: episode.title,
               publishedAt: episode.publishedAt,
-              releaseDate: dayMonthDate(episode.publishedAt),
+              releaseDate: monthDateYearFormat(episode.publishedAt),
               id: epMetric.id,
               downloads: mapMetricsToTimeseriesData(downloads),
               totalForPeriod: getTotal(downloads)
@@ -165,18 +165,21 @@ export class DownloadsTableComponent implements OnDestroy {
   }
 
   dateFormat(date: Date): string {
-    if (this.filter && this.filter.interval) {
-      switch (this.filter.interval.key) {
-        case INTERVAL_DAILY.key:
-          return dayMonthDate(date);
-        case INTERVAL_HOURLY.key:
-        case INTERVAL_15MIN.key:
+    if (this.filter) {
+      switch (this.filter.interval) {
+        case INTERVAL_MONTHLY:
+          return monthYearFormat(date);
+        case INTERVAL_WEEKLY:
+        case INTERVAL_DAILY:
+          return dayMonthDateFormat(date);
+        case INTERVAL_HOURLY:
+        case INTERVAL_15MIN:
           return hourlyDateFormat(date);
         default:
-          return dayMonthDate(date);
+          return dayMonthDateFormat(date);
       }
     } else {
-      return dayMonthDate(date);
+      return dayMonthDateFormat(date);
     }
   }
 }

--- a/src/app/ngrx/model/index.ts
+++ b/src/app/ngrx/model/index.ts
@@ -1,6 +1,6 @@
 export { PodcastModel } from './podcast.model';
 export { EpisodeModel } from './episode.model';
-export { INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN, IntervalModel,
+export { INTERVAL_MONTHLY, INTERVAL_WEEKLY, INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN, IntervalModel,
   PodcastMetricsModel, EpisodeMetricsModel, MetricsType } from './metrics.model';
 export { FilterModel, DateRangeModel, TODAY, THIS_WEEK, TWO_WEEKS, THIS_MONTH, THREE_MONTHS, THIS_YEAR,
   YESTERDAY, LAST_WEEK, PRIOR_TWO_WEEKS, LAST_MONTH, PRIOR_THREE_MONTHS, LAST_YEAR } from './filter.model';

--- a/src/app/ngrx/model/metrics.model.ts
+++ b/src/app/ngrx/model/metrics.model.ts
@@ -4,6 +4,8 @@ export interface IntervalModel {
   key: string;
 }
 
+export const INTERVAL_MONTHLY: IntervalModel = { value: '1M', name: 'monthly', key: 'monthly' };
+export const INTERVAL_WEEKLY: IntervalModel = { value: '1w', name: 'weekly', key: 'weekly' };
 export const INTERVAL_DAILY: IntervalModel = { value: '1d', name: 'daily', key: 'daily' };
 export const INTERVAL_HOURLY: IntervalModel = { value: '1h', name: 'hourly', key: 'hourly' };
 export const INTERVAL_15MIN: IntervalModel = { value: '15m', name: '15 minutes' , key: 'fifteenMin'};

--- a/src/app/shared/filter/date/standard-date-range.component.ts
+++ b/src/app/shared/filter/date/standard-date-range.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
-import { IntervalModel, INTERVAL_15MIN, INTERVAL_HOURLY, INTERVAL_DAILY,
+import { IntervalModel, INTERVAL_15MIN, INTERVAL_HOURLY, INTERVAL_DAILY, INTERVAL_WEEKLY, INTERVAL_MONTHLY,
   TODAY, THIS_WEEK, TWO_WEEKS, THIS_MONTH, THREE_MONTHS, THIS_YEAR,
   YESTERDAY, LAST_WEEK, PRIOR_TWO_WEEKS, LAST_MONTH, PRIOR_THREE_MONTHS, LAST_YEAR } from '../../../ngrx/model';
 import { isMoreThanXDays, endOfTodayUTC, beginningOfTwoWeeksUTC, beginningOfThisMonthUTC,
@@ -35,13 +35,13 @@ export class StandardDateRangeComponent implements OnChanges {
       this.rangeOptions.push(THIS_MONTH);
     }
 
-    if (this.interval === INTERVAL_DAILY ||
+    if (this.interval === INTERVAL_DAILY || this.interval === INTERVAL_WEEKLY || this.interval === INTERVAL_MONTHLY ||
       (this.interval === INTERVAL_15MIN && !isMoreThanXDays(10, beginningOfThreeMonthsUTC(), endOfTodayUTC())) ||
       (this.interval === INTERVAL_HOURLY && !isMoreThanXDays(40, beginningOfThreeMonthsUTC(), endOfTodayUTC()))) {
       this.rangeOptions.push(THREE_MONTHS);
     }
 
-    if (this.interval === INTERVAL_DAILY ||
+    if (this.interval === INTERVAL_DAILY || this.interval === INTERVAL_WEEKLY || this.interval === INTERVAL_MONTHLY ||
       (this.interval === INTERVAL_15MIN && !isMoreThanXDays(10, beginningOfThisYearUTC(), endOfTodayUTC())) ||
       (this.interval === INTERVAL_HOURLY && !isMoreThanXDays(40, beginningOfThisYearUTC(), endOfTodayUTC()))) {
       this.rangeOptions.push(THIS_YEAR);

--- a/src/app/shared/filter/filter.component.spec.ts
+++ b/src/app/shared/filter/filter.component.spec.ts
@@ -17,9 +17,10 @@ import { StandardDateRangeComponent } from './date/standard-date-range.component
 
 import { reducers } from '../../ngrx/reducers';
 import { CastleFilterAction } from '../../ngrx/actions';
-import { FilterModel, YESTERDAY, TWO_WEEKS, INTERVAL_DAILY, INTERVAL_HOURLY } from '../../ngrx/model';
-import { endOfTodayUTC, beginningOfYesterdayUTC, endOfYesterdayUTC,
-  beginningOfTwoWeeksUTC, getRange } from '../util/date.util';
+import { FilterModel, TODAY, YESTERDAY, TWO_WEEKS,
+  INTERVAL_MONTHLY, INTERVAL_WEEKLY, INTERVAL_DAILY, INTERVAL_HOURLY } from '../../ngrx/model';
+import { beginningOfTodayUTC, endOfTodayUTC, beginningOfYesterdayUTC, endOfYesterdayUTC, beginningOfThisWeekUTC,
+  beginningOfTwoWeeksUTC, beginningOfThisMonthUTC, getRange } from '../util/date.util';
 
 describe('FilterComponent', () => {
   let comp: FilterComponent;
@@ -84,5 +85,22 @@ describe('FilterComponent', () => {
     });
     comp.onApply();
     expect(comp.store.dispatch).toHaveBeenCalled();
+  });
+
+  it('should normalize dates to interval when interval is selected', () => {
+    comp.onIntervalChange(INTERVAL_MONTHLY);
+    expect(comp.filter.beginDate.valueOf()).toEqual(beginningOfThisMonthUTC().valueOf());
+  });
+
+  it('should normalize dates to interval on apply', () => {
+    comp.filter.interval = INTERVAL_WEEKLY;
+    comp.onDateRangeChange({
+      standardRange: TODAY,
+      range: getRange(TODAY),
+      beginDate: beginningOfTodayUTC().toDate(),
+      endDate: endOfTodayUTC().toDate()
+    });
+    comp.onApply();
+    expect(comp.filter.beginDate.valueOf()).toEqual(beginningOfThisWeekUTC().valueOf());
   });
 });

--- a/src/app/shared/filter/interval.component.spec.ts
+++ b/src/app/shared/filter/interval.component.spec.ts
@@ -42,6 +42,6 @@ describe('IntervalComponent', () => {
   });
 
   it('should limit interval according to begin and end dates', () => {
-    expect(comp.intervalOptions.length).toEqual(2); // DAILY and HOURLY
+    expect(comp.intervalOptions.length).toEqual(4); // MONTHLY, WEEKLY, DAILY, and HOURLY
   });
 });

--- a/src/app/shared/filter/interval.component.ts
+++ b/src/app/shared/filter/interval.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
-import { FilterModel, IntervalModel, INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN } from '../../ngrx/model';
+import { FilterModel, IntervalModel,
+  INTERVAL_MONTHLY, INTERVAL_WEEKLY, INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN } from '../../ngrx/model';
 import { isMoreThanXDays } from '../util/date.util';
 
 @Component({
@@ -26,15 +27,21 @@ export class IntervalComponent implements OnChanges {
        */
       if (isMoreThanXDays(40, this.filter.beginDate, this.filter.endDate)) {
         this.intervalOptions = [
+          [INTERVAL_MONTHLY.name, INTERVAL_MONTHLY],
+          [INTERVAL_WEEKLY.name, INTERVAL_WEEKLY],
           [INTERVAL_DAILY.name, INTERVAL_DAILY]
         ];
       } else if (isMoreThanXDays(10, this.filter.beginDate, this.filter.endDate)) {
         this.intervalOptions = [
+          [INTERVAL_MONTHLY.name, INTERVAL_MONTHLY],
+          [INTERVAL_WEEKLY.name, INTERVAL_WEEKLY],
           [INTERVAL_DAILY.name, INTERVAL_DAILY],
           [INTERVAL_HOURLY.name, INTERVAL_HOURLY],
         ];
       } else {
         this.intervalOptions = [
+          [INTERVAL_MONTHLY.name, INTERVAL_MONTHLY],
+          [INTERVAL_WEEKLY.name, INTERVAL_WEEKLY],
           [INTERVAL_DAILY.name, INTERVAL_DAILY],
           [INTERVAL_HOURLY.name, INTERVAL_HOURLY],
           [INTERVAL_15MIN.name, INTERVAL_15MIN]

--- a/src/app/shared/util/chart.util.spec.ts
+++ b/src/app/shared/util/chart.util.spec.ts
@@ -29,15 +29,4 @@ describe('chart.util', () => {
     // if we subtract two of the timeseries datasets from each other, should have negative values
     expect(subtracted[0].value).toEqual(timeseries[0].value * -1);
   });
-
-  it('should format dates in UTC', () => {
-    const date = new Date();
-    let utcString = chartUtil.UTCDateFormat(date);
-    const search = utcString.match(/..:..:../);
-    expect(parseInt(utcString.slice(search.index, search.index + 2), 10)).toEqual(date.getUTCHours());
-    utcString = chartUtil.dailyDateFormat(date);
-    expect(parseInt(utcString.slice(utcString.indexOf('/') + 1), 10)).toEqual(date.getUTCDate());
-    utcString = chartUtil.hourlyDateFormat(date);
-    expect(parseInt(utcString.slice(utcString.indexOf(':') + 1), 10)).toEqual(date.getUTCMinutes());
-  });
 });

--- a/src/app/shared/util/chart.util.ts
+++ b/src/app/shared/util/chart.util.ts
@@ -42,14 +42,22 @@ export const dailyDateFormat = (date: Date): string => {
   return dayOfWeek(date.getUTCDay()) + ' ' + (date.getUTCMonth() + 1) + '/' + date.getUTCDate();
 };
 
-export const dayMonthDate = (date: Date): string => {
+export const dayMonthDateFormat = (date: Date): string => {
   return date.getUTCMonth() + 1 + '/' + date.getUTCDate();
+};
+
+export const monthDateYearFormat = (date: Date): string => {
+  return date.getUTCMonth() + 1 + '/' + date.getUTCDate() + '/' + date.getUTCFullYear() % 100;
 };
 
 export const hourlyDateFormat = (date: Date): string => {
   const minutes = date.getUTCMinutes() < 10 ? '0' + date.getUTCMinutes() : date.getUTCMinutes();
   return (date.getUTCMonth() + 1) + '/' + date.getUTCDate() + ' ' +
     date.getUTCHours() + ':' + minutes;
+};
+
+export const monthYearFormat = (date: Date): string => {
+  return date.getUTCMonth() + 1 + '/' + date.getUTCFullYear() % 100;
 };
 
 export const baseColor = 'rgb(32, 80, 96)';

--- a/src/app/shared/util/chart.util.ts
+++ b/src/app/shared/util/chart.util.ts
@@ -16,50 +16,6 @@ export const subtractTimeseriesDatasets = (from: TimeseriesDatumModel[], dataset
   });
 };
 
-export const UTCDateFormat = (date: Date): string => {
-  return date.toUTCString();
-};
-
-export const dailyDateFormat = (date: Date): string => {
-  const dayOfWeek = (day: number): string => {
-    switch (day) {
-      case 0:
-        return 'Sun';
-      case 1:
-        return 'Mon';
-      case 2:
-        return 'Tue';
-      case 3:
-        return 'Wed';
-      case 4:
-        return 'Thu';
-      case 5:
-        return 'Fri';
-      case 6:
-        return 'Sat';
-    }
-  };
-  return dayOfWeek(date.getUTCDay()) + ' ' + (date.getUTCMonth() + 1) + '/' + date.getUTCDate();
-};
-
-export const dayMonthDateFormat = (date: Date): string => {
-  return date.getUTCMonth() + 1 + '/' + date.getUTCDate();
-};
-
-export const monthDateYearFormat = (date: Date): string => {
-  return date.getUTCMonth() + 1 + '/' + date.getUTCDate() + '/' + date.getUTCFullYear() % 100;
-};
-
-export const hourlyDateFormat = (date: Date): string => {
-  const minutes = date.getUTCMinutes() < 10 ? '0' + date.getUTCMinutes() : date.getUTCMinutes();
-  return (date.getUTCMonth() + 1) + '/' + date.getUTCDate() + ' ' +
-    date.getUTCHours() + ':' + minutes;
-};
-
-export const monthYearFormat = (date: Date): string => {
-  return date.getUTCMonth() + 1 + '/' + date.getUTCFullYear() % 100;
-};
-
 export const baseColor = 'rgb(32, 80, 96)';
 export const neutralColor = '#a3a3a3';
 

--- a/src/app/shared/util/date.util.spec.ts
+++ b/src/app/shared/util/date.util.spec.ts
@@ -4,7 +4,7 @@ import { isMoreThanXDays, beginningOfTodayUTC, endOfTodayUTC,
   beginningOfPriorTwoWeeksUTC, endOfPriorTwoWeeksUTC, beginningOfLastMonthUTC, endOfLastMonthUTC,
   beginningOfPriorThreeMonthsUTC, endOfPriorThreeMonthsUTC, beginningOfLastYearUTC, endOfLastYearUTC,
   getBeginEndDateFromStandardRange, getStandardRangeForBeginEndDate, getRange, getMillisecondsOfInterval,
-  roundDateToBeginOfInterval } from './date.util';
+  roundDateToBeginOfInterval, UTCDateFormat, dailyDateFormat, hourlyDateFormat } from './date.util';
 import { DateRangeModel, INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN,
   TODAY, YESTERDAY, THIS_WEEK, LAST_WEEK, TWO_WEEKS, PRIOR_TWO_WEEKS, THIS_MONTH, LAST_MONTH,
   THREE_MONTHS, PRIOR_THREE_MONTHS, THIS_YEAR, LAST_YEAR } from '../../ngrx/model';
@@ -127,5 +127,16 @@ describe('date util', () => {
     expect(threeMonths.beginDate.getUTCDate()).toEqual(1);
     expect(threeMonths.beginDate.valueOf()).toEqual(beginningOfPriorThreeMonthsUTC().valueOf());
     expect(threeMonths.endDate.valueOf()).toBeLessThanOrEqual(endOfPriorThreeMonthsUTC().valueOf());
+  });
+
+  it('should format dates in UTC', () => {
+    const date = new Date();
+    let utcString = UTCDateFormat(date);
+    const search = utcString.match(/..:..:../);
+    expect(parseInt(utcString.slice(search.index, search.index + 2), 10)).toEqual(date.getUTCHours());
+    utcString = dailyDateFormat(date);
+    expect(parseInt(utcString.slice(utcString.indexOf('/') + 1), 10)).toEqual(date.getUTCDate());
+    utcString = hourlyDateFormat(date);
+    expect(parseInt(utcString.slice(utcString.indexOf(':') + 1), 10)).toEqual(date.getUTCMinutes());
   });
 });

--- a/src/app/shared/util/date.util.spec.ts
+++ b/src/app/shared/util/date.util.spec.ts
@@ -3,7 +3,8 @@ import { isMoreThanXDays, beginningOfTodayUTC, endOfTodayUTC,
   beginningOfYesterdayUTC, endOfYesterdayUTC, beginningOfLastWeekUTC, endOfLastWeekUTC,
   beginningOfPriorTwoWeeksUTC, endOfPriorTwoWeeksUTC, beginningOfLastMonthUTC, endOfLastMonthUTC,
   beginningOfPriorThreeMonthsUTC, endOfPriorThreeMonthsUTC, beginningOfLastYearUTC, endOfLastYearUTC,
-  getBeginEndDateFromStandardRange, getStandardRangeForBeginEndDate, getRange, getMillisecondsOfInterval, roundDateToInterval } from './date.util';
+  getBeginEndDateFromStandardRange, getStandardRangeForBeginEndDate, getRange, getMillisecondsOfInterval,
+  roundDateToBeginOfInterval } from './date.util';
 import { DateRangeModel, INTERVAL_DAILY, INTERVAL_HOURLY, INTERVAL_15MIN,
   TODAY, YESTERDAY, THIS_WEEK, LAST_WEEK, TWO_WEEKS, PRIOR_TWO_WEEKS, THIS_MONTH, LAST_MONTH,
   THREE_MONTHS, PRIOR_THREE_MONTHS, THIS_YEAR, LAST_YEAR } from '../../ngrx/model';
@@ -76,9 +77,9 @@ describe('date util', () => {
 
   it('should round begin date to beginning of interval', () => {
     const today = new Date();
-    const daily = roundDateToInterval(today, INTERVAL_DAILY);
-    const hourly = roundDateToInterval(today, INTERVAL_HOURLY);
-    const fifteenMin = roundDateToInterval(today, INTERVAL_15MIN);
+    const daily = roundDateToBeginOfInterval(today, INTERVAL_DAILY);
+    const hourly = roundDateToBeginOfInterval(today, INTERVAL_HOURLY);
+    const fifteenMin = roundDateToBeginOfInterval(today, INTERVAL_15MIN);
     expect(daily.valueOf()).toEqual(beginningOfTodayUTC().valueOf());
     expect(hourly.getHours()).toEqual(today.getHours());
     expect(hourly.getMinutes()).toEqual(0);

--- a/src/app/shared/util/date.util.ts
+++ b/src/app/shared/util/date.util.ts
@@ -308,3 +308,47 @@ export const getAmountOfIntervals = (beginDate: Date, endDate: Date, interval: I
       break;
   }
 };
+
+export const UTCDateFormat = (date: Date): string => {
+  return date.toUTCString();
+};
+
+export const dailyDateFormat = (date: Date): string => {
+  const dayOfWeek = (day: number): string => {
+    switch (day) {
+      case 0:
+        return 'Sun';
+      case 1:
+        return 'Mon';
+      case 2:
+        return 'Tue';
+      case 3:
+        return 'Wed';
+      case 4:
+        return 'Thu';
+      case 5:
+        return 'Fri';
+      case 6:
+        return 'Sat';
+    }
+  };
+  return dayOfWeek(date.getUTCDay()) + ' ' + (date.getUTCMonth() + 1) + '/' + date.getUTCDate();
+};
+
+export const dayMonthDateFormat = (date: Date): string => {
+  return date.getUTCMonth() + 1 + '/' + date.getUTCDate();
+};
+
+export const monthDateYearFormat = (date: Date): string => {
+  return date.getUTCMonth() + 1 + '/' + date.getUTCDate() + '/' + date.getUTCFullYear() % 100;
+};
+
+export const hourlyDateFormat = (date: Date): string => {
+  const minutes = date.getUTCMinutes() < 10 ? '0' + date.getUTCMinutes() : date.getUTCMinutes();
+  return (date.getUTCMonth() + 1) + '/' + date.getUTCDate() + ' ' +
+    date.getUTCHours() + ':' + minutes;
+};
+
+export const monthYearFormat = (date: Date): string => {
+  return date.getUTCMonth() + 1 + '/' + date.getUTCFullYear() % 100;
+};

--- a/src/app/shared/util/date.util.ts
+++ b/src/app/shared/util/date.util.ts
@@ -268,21 +268,23 @@ export const roundDateToBeginOfInterval = (date: Date, interval: IntervalModel):
 };
 
 export const roundDateToEndOfInterval = (date: Date, interval: IntervalModel): Date => {
-  const today = new Date();
-  if (date.getUTCMonth() === today.getUTCMonth() &&
-    (interval === INTERVAL_MONTHLY || interval === INTERVAL_WEEKLY)) {
-    return endOfTodayUTC().toDate();
-  } else if (interval === INTERVAL_MONTHLY) {
-    return moment(date.valueOf())
+  if (interval === INTERVAL_MONTHLY) {
+    return moment.min(
+      moment(date.valueOf())
       .add(1, 'months')
       .date(1).hours(23).minutes(59).seconds(59).milliseconds(999)
-      .subtract(1, 'days').toDate();
+      .subtract(1, 'days'),
+      endOfTodayUTC()).toDate();
   } else if (interval === INTERVAL_WEEKLY) {
     const daysIntoWeek = date.getUTCDay();
     // if date goes negative, the overflow gets normalized
-    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + (7 - daysIntoWeek), 23, 59, 59, 999));
+    return moment.min(
+      moment(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + (6 - daysIntoWeek), 23, 59, 59, 999)).utc(),
+      endOfTodayUTC()).toDate();
   } else if (interval === INTERVAL_DAILY) {
-    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59, 999));
+    return moment.min(
+      moment(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59, 999)).utc(),
+      endOfTodayUTC()).toDate();
   } else {
     // hourly and 15 min data should just show the beginning of the interval
     // (and there is where extracting these helper functions could lead to later trouble...)

--- a/src/app/shared/util/date.util.ts
+++ b/src/app/shared/util/date.util.ts
@@ -270,7 +270,7 @@ export const roundDateToBeginOfInterval = (date: Date, interval: IntervalModel):
 export const roundDateToEndOfInterval = (date: Date, interval: IntervalModel): Date => {
   if (interval === INTERVAL_MONTHLY) {
     return moment.min(
-      moment(date.valueOf())
+      moment(date.valueOf()).utc()
       .add(1, 'months')
       .date(1).hours(23).minutes(59).seconds(59).milliseconds(999)
       .subtract(1, 'days'),
@@ -305,7 +305,7 @@ export const getAmountOfIntervals = (beginDate: Date, endDate: Date, interval: I
     case INTERVAL_WEEKLY:
       return 1 + (duration / (1000 * 60 * 60 * 24 * 7));
     case INTERVAL_MONTHLY:
-      return 1 + (12 * endDate.getUTCFullYear() - beginDate.getUTCFullYear()) + (endDate.getUTCMonth() - beginDate.getUTCMonth());
+      return 1 + (12 * endDate.getUTCFullYear() - 12 * beginDate.getUTCFullYear()) + (endDate.getUTCMonth() - beginDate.getUTCMonth());
     default:
       break;
   }
@@ -345,12 +345,12 @@ export const monthDateYearFormat = (date: Date): string => {
   return date.getUTCMonth() + 1 + '/' + date.getUTCDate() + '/' + date.getUTCFullYear() % 100;
 };
 
+export const monthYearFormat = (date: Date): string => {
+  return date.getUTCMonth() + 1 + '/' + date.getUTCFullYear() % 100;
+};
+
 export const hourlyDateFormat = (date: Date): string => {
   const minutes = date.getUTCMinutes() < 10 ? '0' + date.getUTCMinutes() : date.getUTCMinutes();
   return (date.getUTCMonth() + 1) + '/' + date.getUTCDate() + ' ' +
     date.getUTCHours() + ':' + minutes;
-};
-
-export const monthYearFormat = (date: Date): string => {
-  return date.getUTCMonth() + 1 + '/' + date.getUTCFullYear() % 100;
 };

--- a/src/app/shared/util/metrics.util.ts
+++ b/src/app/shared/util/metrics.util.ts
@@ -1,6 +1,6 @@
 import { PodcastModel, EpisodeModel, FilterModel, MetricsType, IntervalModel,
   PodcastMetricsModel, EpisodeMetricsModel } from '../../ngrx/model';
-import { roundDateToInterval } from './date.util';
+import { roundDateToBeginOfInterval } from './date.util';
 
 export const filterPodcasts = (filter: FilterModel, podcasts: PodcastModel[]): PodcastModel => {
   if (filter.podcast && podcasts) {
@@ -27,7 +27,7 @@ export const filterEpisodes = (filter: FilterModel, episodes: EpisodeModel[]) =>
 export const filterMetricsByDate = (beginDate: Date, endDate: Date, interval: IntervalModel, metrics: any[][]): any[][] => {
   const findEntryByDate = (date: Date) => {
     return metrics.findIndex(m => {
-      return new Date(m[0]).valueOf() === roundDateToInterval(date, interval).valueOf();
+      return new Date(m[0]).valueOf() === roundDateToBeginOfInterval(date, interval).valueOf();
     });
   };
   const begin = findEntryByDate(beginDate);


### PR DESCRIPTION
#59 support weekly and monthly intervals
 * weekly and monthly are available in the interval dropdown
 * when choosing an interval, if the dates do not match up, they will be normalized to the beginning and end of the interval. For hourly and monthly data, the beginning of the interval is used because the data is inclusive and the timepicker doesn't have any steps between intervals. In order to allow the user to make adjustments to the filter parameters without taking away options, the interval is not limited to the date range selected; instead the date range is normalized on Apply

#60 this really felt incomplete without also doing the change to show a bar chart when there are less than 4 data points