### PR TITLE
fixes table first column jank

### DIFF
--- a/src/app/downloads/downloads-table.component.css
+++ b/src/app/downloads/downloads-table.component.css
@@ -1,54 +1,42 @@
 .table-wrapper {
-  position: relative;
+  display: flex;
 }
 table {
-  margin-left: 150px;
-  overflow-x: auto;
-  border-collapse: collapse;
   line-height: 14px;
-  display: block;
+  table-layout: fixed;
+  border-collapse: collapse;
 }
 th, td {
   padding: 5px;
-  text-align: center;
   vertical-align: middle;
   border: 3px solid #f0f0f0;
   background: white;
   width: 45px;
+}
+th {
+  height: 45px;
+  text-align: center;
 }
 td {
   text-align: right;
   font-size: 12px;
   white-space: nowrap;
 }
-/* first column sticks to the left as you scroll right */
-.sticky {
-  position: absolute;
-  left: 0;
-  width: 150px;
+table.sticky th, table.sticky td {
+  min-width: 150px;
+  max-width: 150px;
   border-right: none;
-  text-align: left;
-}
-th.sticky {
-  top: 0;
-  height: 44px;
-}
-td.sticky {
-  margin-top: -1px;
   text-overflow: ellipsis;
   overflow: hidden;
+  text-align: left;
 }
-.sticky .valign {
-  position: relative;
-  min-height: 100%;
-  display: flex;
-  align-items: center;
-  font-weight: inherit;
+.scroll-x-wrapper {
+  max-width: calc(100% - 150px);
+  overflow-x: auto;
 }
-
-tbody td:nth-child(3) {
+table.scroll-x tbody td:nth-child(2) {
   font-weight: 700;
 }
-thead th:nth-child(2), th:nth-child(3) {
+table.scroll-x th:nth-child(1), th:nth-child(2) {
   min-width: 75px;
 }

--- a/src/app/downloads/downloads-table.component.ts
+++ b/src/app/downloads/downloads-table.component.ts
@@ -13,31 +13,45 @@ import * as moment from 'moment';
 @Component({
   selector: 'metrics-downloads-table',
   template: `
-    <div class="table-wrapper">
-      <table *ngIf="podcastTableData">
+    <div class="table-wrapper" *ngIf="podcastTableData">
+      <table class="sticky">
         <thead>
           <tr>
-            <th class="sticky"><div class="valign">Episode</div></th>
-            <th>Release Date</th>
-            <th>Total for Period</th>
-            <th *ngFor="let date of dateRange">{{date}}</th>
+            <th>Episode</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td class="sticky">{{podcastTableData.title}}</td>
-            <td>{{podcastTableData.releaseDate}}</td>
-            <td>{{podcastTableData.totalForPeriod | largeNumber}}</td>
-            <td *ngFor="let download of podcastTableData.downloads">{{download.value | largeNumber}}</td>
+            <td>{{podcastTableData.title}}</td>
           </tr>
           <tr *ngFor="let episode of episodeTableData">
-            <td class="sticky">{{episode.title}}</td>
-            <td>{{episode.releaseDate}}</td>
-            <td>{{episode.totalForPeriod | largeNumber}}</td>
-            <td *ngFor="let download of episode.downloads">{{download.value | largeNumber}}</td>
+            <td>{{episode.title}}</td>
           </tr>
         </tbody>
       </table>
+      <div class="scroll-x-wrapper">
+        <table class="scroll-x">
+          <thead>
+            <tr>
+              <th>Release Date</th>
+              <th>Total for Period</th>
+              <th *ngFor="let date of dateRange">{{date}}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>{{podcastTableData.releaseDate}}</td>
+              <td>{{podcastTableData.totalForPeriod | largeNumber}}</td>
+              <td *ngFor="let download of podcastTableData.downloads">{{download.value | largeNumber}}</td>
+            </tr>
+            <tr *ngFor="let episode of episodeTableData">
+              <td>{{episode.releaseDate}}</td>
+              <td>{{episode.totalForPeriod | largeNumber}}</td>
+              <td *ngFor="let download of episode.downloads">{{download.value | largeNumber}}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   `,
   styleUrls: ['downloads-table.component.css']


### PR DESCRIPTION
Sometimes when you scrolled the table horizontally and hovered the graph to show the tooltip or opened the episodes dropdown, this would happen:
<img width="653" alt="screen shot 2017-10-27 at 5 45 06 pm" src="https://user-images.githubusercontent.com/2250413/33383222-59e8c038-d4e8-11e7-80e0-79c5a85d85cd.png">

Semantically, this is less good splitting it out into two tables, but I wasn't sure how to fix it with the sticky negative margin. The redesign removes all the individual data points from this table anyway and only shows all time totals and averages, so eventually it won't need this horizontal scrolling (unless we decide to include it in reports, _if_ we do them.)