### PR TITLE
use transparent border and remove btn-icon margin

### DIFF
--- a/src/app/shared/menu/date/custom-date-range-dropdown.component.css
+++ b/src/app/shared/menu/date/custom-date-range-dropdown.component.css
@@ -2,11 +2,10 @@
   min-width: 36px;
 }
 .dropdown-button > button {
-  border: 0px;
-  max-width: 24px;
-  max-height: 36px;
+  border: 6px solid transparent;
+  max-width: 36px;
   padding: 0px;
-  margin: 6px;
+  margin: 0px;
 }
 
 .dropdown-content {

--- a/src/app/shared/menu/dropdown.css
+++ b/src/app/shared/menu/dropdown.css
@@ -19,7 +19,7 @@
   border: 0px;
   background-color: transparent;
   color: #676767;
-  height: 24px;
+  height: 36px;
   padding: 0px 6px;
   line-height: 36px;
   white-space: nowrap;


### PR DESCRIPTION
I added a transparent border around the calendar btn-icon icon in the menu bar in order to make the area outside the icon clickable and resolve #146 