### PR TITLE
range then bucket

### DIFF
--- a/src/app/downloads/downloads-chart.component.spec.ts
+++ b/src/app/downloads/downloads-chart.component.spec.ts
@@ -191,9 +191,17 @@ describe('DownloadsChartComponent', () => {
     it('should show bar chart if there are less than 4 data points; otherwise, area', () => {
       expect(comp.chartType).toEqual('area');
       comp.store.dispatch(new CustomRouterNavigationAction({routerState: {
-        beginDate: new Date('2017-09-05T00:00:00Z'),
-        endDate: new Date('2017-09-07T00:00:00Z')
+        beginDate: new Date(podDownloads[0][0].toString()),
+        endDate: new Date(podDownloads[2][0].toString())
       }}));
+      comp.store.dispatch(new CastlePodcastMetricsSuccessAction({
+        seriesId: podcast.seriesId, feederId: podcast.feederId, metricsPropertyName, metrics: podDownloads.slice(0, 3)}));
+      comp.store.dispatch(new CastleEpisodeMetricsSuccessAction({
+        seriesId: episodes[1].seriesId, page: episodes[1].page, id: episodes[1].id, guid: episodes[1].guid,
+        metricsPropertyName, metrics: ep1Downloads.slice(0, 3)}));
+      comp.store.dispatch(new CastleEpisodeMetricsSuccessAction({
+        seriesId: episodes[1].seriesId, page: episodes[1].page, id: episodes[1].id, guid: episodes[1].guid,
+        metricsPropertyName, metrics: ep1Downloads.slice(0, 3)}));
       fix.detectChanges();
       expect(comp.chartType).toEqual('bar');
     });

--- a/src/app/downloads/downloads-chart.component.ts
+++ b/src/app/downloads/downloads-chart.component.ts
@@ -9,7 +9,6 @@ import { selectRouter, selectEpisodes, selectPodcastMetrics, selectEpisodeMetric
 import { findPodcastMetrics, filterEpisodeMetricsPage, metricsData, getTotal } from '../shared/util/metrics.util';
 import { mapMetricsToTimeseriesData, subtractTimeseriesDatasets, neutralColor } from '../shared/util/chart.util';
 import * as dateFormat from '../shared/util/date/date.format';
-import * as dateUtil from '../shared/util/date/date.util';
 
 @Component({
   selector: 'metrics-downloads-chart',
@@ -101,13 +100,10 @@ export class DownloadsChartComponent implements OnDestroy {
   updateChartData() {
     if (this.routerState.beginDate && this.routerState.endDate && this.routerState.interval && this.routerState.chartType) {
       this.chartData = null;
-      // no partial date range coverage charts, makes the loading UX too jerky
-      const expectedLength = dateUtil.getAmountOfIntervals(this.routerState.beginDate, this.routerState.endDate, this.routerState.interval);
       switch (this.routerState.chartType) {
         case CHARTTYPE_STACKED:
-          if (this.podcastChartData && this.podcastMetrics.charted && this.podcastChartData.data.length === expectedLength &&
-            (this.episodeChartData && this.episodeChartData.length > 0 &&
-            this.episodeChartData.every(chartData => chartData.data.length === expectedLength))) {
+          if (this.podcastChartData && this.podcastMetrics.charted &&
+            (this.episodeChartData && this.episodeChartData.length > 0)) {
             // if we have episodes to combine with podcast total
             const episodeDatasets = this.episodeChartData.map(m => m.data);
             const allOtherEpisodesData: TimeseriesChartModel = {
@@ -119,8 +115,7 @@ export class DownloadsChartComponent implements OnDestroy {
           } else if (this.podcastChartData && this.podcastMetrics.charted &&
             this.podcastChartData.data.length > 0 && this.episodeChartData.length === 0) {
             this.chartData = [this.podcastChartData];
-          } else if (this.episodeChartData && this.episodeChartData.length > 0 &&
-            this.episodeChartData.every(chartData => chartData.data.length === expectedLength)) {
+          } else if (this.episodeChartData && this.episodeChartData.length > 0) {
             this.chartData = this.episodeChartData;
           }
           break;
@@ -130,8 +125,7 @@ export class DownloadsChartComponent implements OnDestroy {
           }
           break;
         case CHARTTYPE_EPISODES:
-          if (this.episodeChartData && this.episodeChartData.length > 0 &&
-            this.episodeChartData.every(chartData => chartData.data.length === expectedLength)) {
+          if (this.episodeChartData && this.episodeChartData.length > 0) {
             this.chartData = this.episodeChartData;
           }
           break;

--- a/src/app/downloads/downloads-chart.component.ts
+++ b/src/app/downloads/downloads-chart.component.ts
@@ -143,7 +143,7 @@ export class DownloadsChartComponent implements OnDestroy {
     if (this.routerState) {
       switch (this.routerState.interval) {
         case INTERVAL_MONTHLY:
-          return dateFormat.monthYear;
+          return dateFormat.monthDateYear;
         case INTERVAL_WEEKLY:
         case INTERVAL_DAILY:
           return dateFormat.monthDate;

--- a/src/app/downloads/downloads-table.component.ts
+++ b/src/app/downloads/downloads-table.component.ts
@@ -92,7 +92,6 @@ export class DownloadsTableComponent implements OnDestroy {
   mapPodcastData() {
     const downloads = metricsData(this.routerState, this.podcastMetrics);
     if (downloads) {
-      const expectedLength = getAmountOfIntervals(this.routerState.beginDate, this.routerState.endDate, this.routerState.interval);
       const totalForPeriod = getTotal(downloads);
       return {
         title: 'All Episodes',
@@ -100,7 +99,7 @@ export class DownloadsTableComponent implements OnDestroy {
         color: neutralColor,
         downloads: mapMetricsToTimeseriesData(downloads),
         totalForPeriod: totalForPeriod,
-        avgPerIntervalForPeriod: Math.round(totalForPeriod / expectedLength),
+        avgPerIntervalForPeriod: Math.round(totalForPeriod / downloads.length),
         allTimeDownloads: this.podcastMetrics.allTimeDownloads,
         charted: this.podcastMetrics.charted
       };
@@ -109,7 +108,6 @@ export class DownloadsTableComponent implements OnDestroy {
 
   mapEpisodeData() {
     if (this.episodes && this.episodeMetrics && this.episodeMetrics.length) {
-      const expectedLength = getAmountOfIntervals(this.routerState.beginDate, this.routerState.endDate, this.routerState.interval);
       return this.episodeMetrics
         .filter(epMetric => this.episodes.find(ep => ep.id === epMetric.id))
         .map((epMetric) => {
@@ -125,7 +123,7 @@ export class DownloadsTableComponent implements OnDestroy {
               id: epMetric.id,
               downloads: mapMetricsToTimeseriesData(downloads),
               totalForPeriod: totalForPeriod,
-              avgPerIntervalForPeriod: Math.round(totalForPeriod / expectedLength),
+              avgPerIntervalForPeriod: Math.round(totalForPeriod / downloads.length),
               allTimeDownloads: epMetric.allTimeDownloads,
               charted: epMetric.charted
             };
@@ -164,7 +162,7 @@ export class DownloadsTableComponent implements OnDestroy {
     if (this.routerState) {
       switch (this.routerState.interval) {
         case INTERVAL_MONTHLY:
-          return dateFormat.monthYear(date);
+          return dateFormat.monthDateYear(date);
         case INTERVAL_WEEKLY:
         case INTERVAL_DAILY:
           return dateFormat.monthDate(date);

--- a/src/app/downloads/downloads-table.component.ts
+++ b/src/app/downloads/downloads-table.component.ts
@@ -10,7 +10,6 @@ import * as ACTIONS from '../ngrx/actions';
 import { findPodcastMetrics, filterPodcastEpisodePage, filterEpisodeMetricsPage, metricsData, getTotal } from '../shared/util/metrics.util';
 import { mapMetricsToTimeseriesData, neutralColor } from '../shared/util/chart.util';
 import * as dateFormat from '../shared/util/date/date.format';
-import { getAmountOfIntervals } from '../shared/util/date/date.util';
 import { isPodcastChanged } from '../shared/util/filter.util';
 import * as moment from 'moment';
 

--- a/src/app/downloads/downloads.component.spec.ts
+++ b/src/app/downloads/downloads.component.spec.ts
@@ -19,8 +19,6 @@ import { EpisodeModel, PodcastModel, RouterModel, ChartType, MetricsType,
 import { reducers } from '../ngrx/reducers';
 import * as ACTIONS from '../ngrx/actions';
 
-import { selectCmsLoading, selectCastleLoading, selectCmsLoaded, selectCastleLoaded } from '../ngrx/reducers';
-
 describe('DownloadsComponent', () => {
   let comp: DownloadsComponent;
   let fix: ComponentFixture<DownloadsComponent>;
@@ -43,7 +41,7 @@ describe('DownloadsComponent', () => {
     title: 'A Pet Talks Episode',
     publishedAt: new Date()
   };
-  const routerState:RouterModel = {
+  const routerState: RouterModel = {
     podcastSeriesId: 37800,
       page: 1,
       beginDate: new Date('2017-08-27T00:00:00Z'),

--- a/src/app/ngrx/effects/routing.effects.ts
+++ b/src/app/ngrx/effects/routing.effects.ts
@@ -146,18 +146,7 @@ export class RoutingEffects {
     .ofType(ActionTypes.ROUTE_ADVANCED_RANGE)
     .map((action: ACTIONS.RouteAdvancedRangeAction) => action.payload)
     .switchMap((payload: ACTIONS.RouteAdvancedRangePayload) => {
-      // just keep doing this for now. soon.
-      const { interval } = payload;
-      const beginDate = dateUtil.roundDateToBeginOfInterval(payload.beginDate, interval);
-      const endDate = dateUtil.roundDateToEndOfInterval(payload.endDate, interval);
-      let standardRange = dateUtil.getStandardRangeForBeginEndDate(payload.beginDate, payload.endDate, interval);
-      // if the dates for the given range are the same but the resulting string does match what is given, keep don't override
-      const payloadRange = dateUtil.getBeginEndDateFromStandardRange(payload.standardRange);
-      if (payload.standardRange !== standardRange &&
-        payloadRange.beginDate.valueOf() === beginDate.valueOf() &&
-        payloadRange.endDate.valueOf() === endDate.valueOf()) {
-        standardRange = payload.standardRange;
-      }
+      const { interval, beginDate, endDate, standardRange } = payload;
       this.routeFromNewRouterState({beginDate, endDate, interval, standardRange});
       return Observable.of(null);
     });

--- a/src/app/ngrx/reducers/router.serializer.spec.ts
+++ b/src/app/ngrx/reducers/router.serializer.spec.ts
@@ -19,7 +19,7 @@ describe('CustomSerializer', () => {
             interval: INTERVAL_HOURLY.key,
             page: '1',
             beginDate: '2017-11-09T00:00:00.000Z',
-            endDate: '2017-11-09T22:00:00.000Z',
+            endDate: '2017-11-09T23:59:59.999Z',
             episodes: '123,1234',
             chartPodcast: 'true'
           }
@@ -33,7 +33,7 @@ describe('CustomSerializer', () => {
       interval: INTERVAL_HOURLY,
       page: 1,
       beginDate: new Date('2017-11-09T00:00:00.000Z'),
-      endDate: new Date('2017-11-09T22:00:00.000Z'),
+      endDate: new Date('2017-11-09T23:59:59.999Z'),
       standardRange: dateUtil.OTHER,
       episodeIds: [123, 1234],
       chartPodcast: true

--- a/src/app/ngrx/reducers/router.serializer.ts
+++ b/src/app/ngrx/reducers/router.serializer.ts
@@ -60,14 +60,14 @@ export class CustomSerializer implements RouterStateSerializer<RouterModel> {
         if (range && (range.beginDate.valueOf() !== router.beginDate.valueOf() ||
           range.endDate.valueOf() !== router.endDate.valueOf())) {
           // route has standard range that does not match begin/end dates
-          router.standardRange = getStandardRangeForBeginEndDate(router.beginDate, router.endDate, router.interval);
+          router.standardRange = getStandardRangeForBeginEndDate(router.beginDate, router.endDate);
         } else {
           // standardRange matches begin/end dates
           router.standardRange = params['standardRange'];
         }
       } else if (router.beginDate && router.endDate && !params['standardRange']) {
         // missing standard range, so set it from begin/end date
-        router.standardRange = getStandardRangeForBeginEndDate(router.beginDate, router.endDate, router.interval);
+        router.standardRange = getStandardRangeForBeginEndDate(router.beginDate, router.endDate);
       } else if (params['standardRange']) {
         // missing begin and/or end dates, so set from standardRange
         router.standardRange = params['standardRange'];

--- a/src/app/ngrx/reducers/router.serializer.ts
+++ b/src/app/ngrx/reducers/router.serializer.ts
@@ -2,7 +2,7 @@ import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { RouterStateSerializer } from '@ngrx/router-store';
 
 import { RouterModel, IntervalList,
-  INTERVAL_HOURLY, METRICSTYPE_DEMOGRAPHICS, METRICSTYPE_DOWNLOADS, METRICSTYPE_TRAFFICSOURCES, MetricsType } from './models';
+  METRICSTYPE_DEMOGRAPHICS, METRICSTYPE_DOWNLOADS, METRICSTYPE_TRAFFICSOURCES, MetricsType } from './models';
 
 import { getBeginEndDateFromStandardRange, getStandardRangeForBeginEndDate } from '../../shared/util/date/date.util';
 

--- a/src/app/ngrx/reducers/router.serializer.ts
+++ b/src/app/ngrx/reducers/router.serializer.ts
@@ -48,12 +48,11 @@ export class CustomSerializer implements RouterStateSerializer<RouterModel> {
         router.beginDate = new Date(params['beginDate']);
       }
       if (params['endDate']) {
-        // Hmmm... params from the RouterStateSnanshot have date strings without milliseconds even though they're in the url
-        // For our purposes, end date is 999 milliseconds except when hourly, so... add it I guess
         router.endDate = new Date(params['endDate']);
-        if (router.interval !== INTERVAL_HOURLY) {
-          router.endDate.setMilliseconds(999);
-        }
+        // Hmmm... params from the RouterStateSnanshot have date strings without milliseconds even though they're in the url
+        // For our purposes, end date is 999 milliseconds, so... add it I guess
+        // This could get weird for hourly data if we ever bring back time pickers
+        router.endDate.setMilliseconds(999);
       }
       if (router.beginDate && router.endDate && params['standardRange']) {
         const range = getBeginEndDateFromStandardRange(params['standardRange']);

--- a/src/app/shared/menu/date/custom-date-range-dropdown.component.spec.ts
+++ b/src/app/shared/menu/date/custom-date-range-dropdown.component.spec.ts
@@ -98,13 +98,6 @@ describe('CustomDateRangeDropdownComponent', () => {
     expect(comp.tempRange.standardRange).toEqual(dateUtil.LAST_WEEK);
   });
 
-  it('keeps tempRange date range in sync with interval', () => {
-    comp.routerState.beginDate = dateUtil.beginningOfTodayUTC().toDate();
-    comp.onIntervalChange(INTERVAL_MONTHLY);
-    expect(comp.routerState.beginDate.valueOf()).toEqual(dateUtil.beginningOfThisMonthUTC().valueOf());
-    expect(comp.routerState.standardRange).toEqual(dateUtil.THIS_MONTH);
-  });
-
   it('should dispatch routing and google analytics actions onApply', () => {
     spyOn(store, 'dispatch');
     comp.onIntervalChange(INTERVAL_MONTHLY);

--- a/src/app/shared/menu/date/custom-date-range-dropdown.component.ts
+++ b/src/app/shared/menu/date/custom-date-range-dropdown.component.ts
@@ -64,7 +64,7 @@ export class CustomDateRangeDropdownComponent {
       this.tempRange.beginDate = dateRange.from;
       this.tempRange.endDate = dateRange.to;
       this.tempRange.standardRange = dateUtil.getStandardRangeForBeginEndDate(
-        this.tempRange.beginDate, this.tempRange.endDate, this.tempRange.interval);
+        this.tempRange.beginDate, this.tempRange.endDate);
       this.userChoseRange = this.CUSTOM_DATE;
     }
   }

--- a/src/app/shared/menu/date/custom-date-range-dropdown.component.ts
+++ b/src/app/shared/menu/date/custom-date-range-dropdown.component.ts
@@ -56,10 +56,6 @@ export class CustomDateRangeDropdownComponent {
 
   onIntervalChange(interval: IntervalModel) {
     this.tempRange.interval = interval;
-    this.tempRange.beginDate = dateUtil.roundDateToBeginOfInterval(this.tempRange.beginDate, interval);
-    this.tempRange.endDate = dateUtil.roundDateToEndOfInterval(this.tempRange.endDate, interval);
-    this.tempRange.standardRange = dateUtil.getStandardRangeForBeginEndDate(
-      this.tempRange.beginDate, this.tempRange.endDate, this.tempRange.interval);
   }
 
   onCustomRangeChange(dateRange: {from: Date, to: Date}) {

--- a/src/app/shared/menu/date/standard-date-range.component.ts
+++ b/src/app/shared/menu/date/standard-date-range.component.ts
@@ -35,18 +35,13 @@ export class StandardDateRangeComponent implements OnChanges {
         ];
       case INTERVAL_DAILY:
       case INTERVAL_WEEKLY:
+      case INTERVAL_MONTHLY:
         return [
           [dateUtil.THIS_WEEK, dateUtil.LAST_WEEK, dateUtil.LAST_7_DAYS],
           [dateUtil.THIS_WEEK_PLUS_7_DAYS],
           [dateUtil.THIS_MONTH, dateUtil.LAST_MONTH, dateUtil.LAST_28_DAYS, dateUtil.LAST_30_DAYS],
           [dateUtil.THIS_MONTH_PLUS_2_MONTHS, dateUtil.LAST_90_DAYS],
           [dateUtil.THIS_YEAR, dateUtil.LAST_365_DAYS]
-        ];
-      case INTERVAL_MONTHLY:
-        return [
-          [dateUtil.THIS_MONTH, dateUtil.LAST_MONTH],
-          [dateUtil.THIS_MONTH_PLUS_2_MONTHS],
-          [dateUtil.THIS_YEAR]
         ];
     }
   }

--- a/src/app/shared/util/date/date.util.spec.ts
+++ b/src/app/shared/util/date/date.util.spec.ts
@@ -1,6 +1,6 @@
 import * as dateUtil from './date.util';
 import * as dateConst from './date.constants';
-import { RouterModel, INTERVAL_MONTHLY, INTERVAL_WEEKLY, INTERVAL_DAILY, INTERVAL_HOURLY } from '../../../ngrx';
+import { INTERVAL_DAILY, INTERVAL_HOURLY } from '../../../ngrx';
 
 describe('date util', () => {
   it('should tell us if dates are more than a specified number of days apart', () => {
@@ -47,25 +47,22 @@ describe('date util', () => {
   });
 
   it('should get standard range from begin and end dates', () => {
-    const thisWeek: RouterModel = {
-      interval: INTERVAL_DAILY,
+    const thisWeek = {
       beginDate: dateUtil.beginningOfThisWeekUTC().toDate(),
       endDate: dateUtil.endOfTodayUTC().toDate()
     };
-    expect(dateUtil.getStandardRangeForBeginEndDate(thisWeek.beginDate, thisWeek.endDate, thisWeek.interval)).toEqual(dateConst.THIS_WEEK);
-    const lastWeek: RouterModel = {
-      interval: INTERVAL_DAILY,
+    expect(dateUtil.getStandardRangeForBeginEndDate(thisWeek.beginDate, thisWeek.endDate)).toEqual(dateConst.THIS_WEEK);
+    const lastWeek = {
       beginDate: dateUtil.beginningOfLastWeekUTC().toDate(),
       endDate: dateUtil.endOfLastWeekUTC().toDate()
     };
-    expect(dateUtil.getStandardRangeForBeginEndDate(lastWeek.beginDate, lastWeek.endDate, lastWeek.interval)).toEqual(dateConst.LAST_WEEK);
-    const other: RouterModel = {
-      interval: INTERVAL_DAILY,
+    expect(dateUtil.getStandardRangeForBeginEndDate(lastWeek.beginDate, lastWeek.endDate)).toEqual(dateConst.LAST_WEEK);
+    const other = {
       beginDate: dateUtil.beginningOfTodayUTC().toDate(),
       endDate: dateUtil.endOfTodayUTC().toDate()
     };
     // TODAY is no longer a valid option, so should match OTHER
-    expect(dateUtil.getStandardRangeForBeginEndDate(other.beginDate, other.endDate, other.interval)).toEqual(dateConst.OTHER);
+    expect(dateUtil.getStandardRangeForBeginEndDate(other.beginDate, other.endDate)).toEqual(dateConst.OTHER);
   });
 
   it('should get amount of milliseconds in interval', () => {
@@ -79,27 +76,6 @@ describe('date util', () => {
     expect(daily.valueOf()).toEqual(dateUtil.beginningOfTodayUTC().valueOf());
     expect(hourly.getHours()).toEqual(today.getHours());
     expect(hourly.getMinutes()).toEqual(0);
-  });
-
-  describe('roundDateToEndOfInterval', () => {
-    it('should round date to end of interval', () => {
-      expect(dateUtil.roundDateToEndOfInterval(dateUtil.beginningOfLastWeekUTC().toDate(), INTERVAL_WEEKLY).valueOf())
-        .toEqual(dateUtil.endOfLastWeekUTC().valueOf());
-    });
-    it('except for dates in the present, which should be rounded to the end of today utc', () => {
-      expect(dateUtil.roundDateToEndOfInterval(dateUtil.beginningOfThisMonthUTC().toDate(), INTERVAL_MONTHLY).valueOf())
-        .toEqual(dateUtil.endOfTodayUTC().valueOf());
-    });
-    it('except for hourly and 15m, which should be rounded to the beginning of the interval', () => {
-      expect(dateUtil.roundDateToEndOfInterval(new Date(2017, 9, 27, 8, 32), INTERVAL_HOURLY).getMinutes()).toEqual(0);
-    });
-    it('dates in the future will be rounded to end of today UTC', () => {
-      const future = new Date();
-      future.setDate(future.getDate() + 1);
-      expect(dateUtil.roundDateToEndOfInterval(future, INTERVAL_DAILY).valueOf()).toEqual(dateUtil.endOfTodayUTC().valueOf());
-      expect(dateUtil.roundDateToEndOfInterval(future, INTERVAL_WEEKLY).valueOf()).toEqual(dateUtil.endOfTodayUTC().valueOf());
-      expect(dateUtil.roundDateToEndOfInterval(future, INTERVAL_MONTHLY).valueOf()).toEqual(dateUtil.endOfTodayUTC().valueOf());
-    });
   });
 
   it('LAST_7_DAYS range should be 6 days ago through today', () => {

--- a/src/app/shared/util/date/date.util.ts
+++ b/src/app/shared/util/date/date.util.ts
@@ -159,54 +159,42 @@ export const getBeginEndDateFromStandardRange = (standardRange: string): {beginD
   }
 };
 
-export const getStandardRangeForBeginEndDate = (beginDate: Date, endDate: Date, interval: IntervalModel) => {
+export const getStandardRangeForBeginEndDate = (beginDate: Date, endDate: Date) => {
   if (beginDate.valueOf() === beginningOfThisWeekUTC().valueOf() &&
-    (endDate.valueOf() === endOfTodayUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfTodayHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfTodayUTC().valueOf()) {
     return dateConst.THIS_WEEK;
   } else if (beginDate.valueOf() === beginningOfLastWeekUTC().valueOf() &&
-    (endDate.valueOf() === endOfLastWeekUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfLastWeekHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfLastWeekUTC().valueOf()) {
     return dateConst.LAST_WEEK;
   } else if (beginDate.valueOf() === beginningOfLast7DaysUTC().valueOf() &&
-    (endDate.valueOf() === endOfTodayUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfTodayHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfTodayUTC().valueOf()) {
     return dateConst.LAST_7_DAYS;
   } else if (beginDate.valueOf() === beginningOfThisWeekPlus7DaysUTC().valueOf() &&
-    (endDate.valueOf() === endOfTodayUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfTodayHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfTodayUTC().valueOf()) {
     return dateConst.THIS_WEEK_PLUS_7_DAYS;
   } else if (beginDate.valueOf() === beginningOfThisMonthUTC().valueOf() &&
-    (endDate.valueOf() === endOfTodayUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfTodayHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfTodayUTC().valueOf()) {
     return dateConst.THIS_MONTH;
   } else if (beginDate.valueOf() === beginningOfLastMonthUTC().valueOf() &&
-    (endDate.valueOf() === endOfLastMonthUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfLastMonthHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfLastMonthUTC().valueOf()) {
     return dateConst.LAST_MONTH;
   } else if (beginDate.valueOf() === beginningOfLast28DaysUTC().valueOf() &&
-    (endDate.valueOf() === endOfTodayUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfTodayHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfTodayUTC().valueOf()) {
     return dateConst.LAST_28_DAYS;
   } else if (beginDate.valueOf() === beginningOfLast30DaysUTC().valueOf() &&
-    (endDate.valueOf() === endOfTodayUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfTodayHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfTodayUTC().valueOf()) {
     return dateConst.LAST_30_DAYS;
   } else if (beginDate.valueOf() === beginningOfThisMonthPlusTwoMonthsUTC().valueOf() &&
-    (endDate.valueOf() === endOfTodayUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfTodayHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfTodayUTC().valueOf()) {
     return dateConst.THIS_MONTH_PLUS_2_MONTHS;
   } else if (beginDate.valueOf() === beginningOfLast90DaysUTC().valueOf() &&
-    (endDate.valueOf() === endOfTodayUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfTodayHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfTodayUTC().valueOf()) {
     return dateConst.LAST_90_DAYS;
   } else if (beginDate.valueOf() === beginningOfThisYearUTC().valueOf() &&
-    (endDate.valueOf() === endOfTodayUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfTodayHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfTodayUTC().valueOf()) {
     return dateConst.THIS_YEAR;
   } else if (beginDate.valueOf() === beginningOfLast365DaysUTC().valueOf() &&
-    (endDate.valueOf() === endOfTodayUTC().valueOf() ||
-    (interval === INTERVAL_HOURLY && endDate.valueOf() === endOfTodayHourlyUTC().valueOf()))) {
+    endDate.valueOf() === endOfTodayUTC().valueOf()) {
     return dateConst.LAST_365_DAYS;
   } else {
     return dateConst.OTHER;
@@ -244,31 +232,6 @@ export const roundDateToBeginOfInterval = (date: Date, interval: IntervalModel):
     } else {
       return date;
     }
-  }
-};
-
-export const roundDateToEndOfInterval = (date: Date, interval: IntervalModel): Date => {
-  if (interval === INTERVAL_MONTHLY) {
-    return moment.min(
-      moment(date.valueOf()).utc()
-      .add(1, 'months')
-      .date(1).hours(23).minutes(59).seconds(59).milliseconds(999)
-      .subtract(1, 'days'),
-      endOfTodayUTC()).toDate();
-  } else if (interval === INTERVAL_WEEKLY) {
-    const daysIntoWeek = date.getUTCDay();
-    // if date goes negative, the overflow gets normalized
-    return moment.min(
-      moment(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + (6 - daysIntoWeek), 23, 59, 59, 999)).utc(),
-      endOfTodayUTC()).toDate();
-  } else if (interval === INTERVAL_DAILY) {
-    return moment.min(
-      moment(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59, 999)).utc(),
-      endOfTodayUTC()).toDate();
-  } else {
-    // hourly data should just show the beginning of the interval
-    // (and there is where extracting these helper functions could lead to later trouble...)
-    return roundDateToBeginOfInterval(date, interval);
   }
 };
 

--- a/src/app/shared/util/date/date.util.ts
+++ b/src/app/shared/util/date/date.util.ts
@@ -14,10 +14,6 @@ export const endOfTodayUTC = () => {
   return moment().utc().hours(23).minutes(59).seconds(59).milliseconds(999);
 };
 
-export const endOfTodayHourlyUTC = () => {
-  return moment().utc().hours(23).minutes(0).seconds(0).milliseconds(0);
-};
-
 export const beginningOfThisWeekUTC = () => {
   const utcDate = beginningOfTodayUTC();
   const daysIntoWeek = utcDate.day();
@@ -32,12 +28,6 @@ export const beginningOfLastWeekUTC = () => {
 
 export const endOfLastWeekUTC = () => {
   const utcDate = endOfTodayUTC();
-  const daysIntoWeek = utcDate.day();
-  return utcDate.subtract(daysIntoWeek + 1, 'days');
-};
-
-export const endOfLastWeekHourlyUTC = () => {
-  const utcDate = endOfTodayHourlyUTC();
   const daysIntoWeek = utcDate.day();
   return utcDate.subtract(daysIntoWeek + 1, 'days');
 };
@@ -62,10 +52,6 @@ export const beginningOfLastMonthUTC = () => {
 
 export const endOfLastMonthUTC = () => {
   return endOfTodayUTC().date(1).subtract(1, 'days'); // 1st of month - 1 day
-};
-
-export const endOfLastMonthHourlyUTC = () => {
-  return endOfTodayHourlyUTC().date(1).subtract(1, 'days'); // 1st of month - 1 day
 };
 
 export const beginningOfLast28DaysUTC = () => {

--- a/src/app/shared/util/metrics.util.spec.ts
+++ b/src/app/shared/util/metrics.util.spec.ts
@@ -1,6 +1,6 @@
 import { PodcastModel, EpisodeModel, RouterModel, PodcastMetricsModel, EpisodeMetricsModel,
   INTERVAL_DAILY, INTERVAL_HOURLY, MetricsType, METRICSTYPE_DOWNLOADS } from '../../ngrx';
-import { filterPodcasts, filterAllPodcastEpisodes, filterMetricsByDate,
+import { filterPodcasts, filterAllPodcastEpisodes,
   findPodcastMetrics, filterEpisodeMetricsPage, metricsData, getTotal } from './metrics.util';
 
 describe('metrics util', () => {
@@ -123,14 +123,11 @@ describe('metrics util', () => {
 
   it('should get metrics array according to interval and metrics type', () => {
     expect(metricsData(routerState, podcastMetrics[0]).length).toEqual(12);
-    expect(metricsData({interval: INTERVAL_HOURLY, metricsType: <MetricsType>METRICSTYPE_DOWNLOADS}, episodeMetrics[0])).toBeUndefined(); // no hourly
+    // no hourly
+    expect(metricsData({interval: INTERVAL_HOURLY, metricsType: <MetricsType>METRICSTYPE_DOWNLOADS}, episodeMetrics[0])).toBeUndefined();
   });
 
   it('should get total of metrics datapoints', () => {
     expect(getTotal(metrics)).toEqual(52522 + 162900 + 46858 + 52522 + 162900 + 46858 + 52522 + 162900 + 46858 + 52522 + 162900 + 46858);
-  });
-
-  it('should routerState metrics by date', () => {
-    expect(filterMetricsByDate(routerState.beginDate, routerState.endDate, routerState.interval, metrics).length).toEqual(7);
   });
 });

--- a/src/app/shared/util/metrics.util.ts
+++ b/src/app/shared/util/metrics.util.ts
@@ -1,6 +1,5 @@
-import { PodcastModel, EpisodeModel, RouterModel, IntervalModel,
-  PodcastMetricsModel, EpisodeMetricsModel, MetricsType, getMetricsProperty } from '../../ngrx';
-import * as dateUtil from './date/date.util';
+import { PodcastModel, EpisodeModel, RouterModel,
+  PodcastMetricsModel, EpisodeMetricsModel, getMetricsProperty } from '../../ngrx';
 
 export const filterPodcasts = (filter: RouterModel, podcasts: PodcastModel[]): PodcastModel => {
   if (filter && filter.podcastSeriesId && podcasts) {
@@ -23,34 +22,13 @@ export const filterPodcastEpisodePage = (filter: RouterModel, episodes: EpisodeM
   }
 };
 
-export const filterMetricsByDate = (beginDate: Date, endDate: Date, interval: IntervalModel, metrics: any[][]): any[][] => {
-  const findEntryByDate = (date: Date) => {
-    return metrics.findIndex(m => {
-      return new Date(m[0]).valueOf() === dateUtil.roundDateToBeginOfInterval(date, interval).valueOf();
-    });
-  };
-  const begin = findEntryByDate(beginDate);
-  const end = findEntryByDate(endDate);
-  if (begin !== -1 && end !== -1) {
-    return metrics.slice(begin, end + 1);
-  } else {
-    return null; // no partial data
-  }
-};
-
 export const findPodcastMetrics =
   (filter: RouterModel, podcastMetrics: PodcastMetricsModel[]): PodcastMetricsModel => {
   if (filter && filter.podcastSeriesId && filter.interval && filter.beginDate && filter.endDate && podcastMetrics) {
     const metricsProperty = getMetricsProperty(filter.interval, filter.metricsType);
     const metrics = podcastMetrics
       .filter((metric: PodcastMetricsModel) => metric.seriesId === filter.podcastSeriesId &&
-        metric[metricsProperty] &&
-        filterMetricsByDate(filter.beginDate, filter.endDate, filter.interval, metric[metricsProperty]))
-      .map((metric: PodcastMetricsModel) => {
-        const filteredMetric = {...metric};
-        filteredMetric[metricsProperty] = filterMetricsByDate(filter.beginDate, filter.endDate, filter.interval, metric[metricsProperty]);
-        return filteredMetric;
-      });
+        metric[metricsProperty]);
     if (metrics && metrics.length) {
       return metrics[0]; // only one entry should match the series id
     }
@@ -64,13 +42,7 @@ export const filterEpisodeMetricsPage =
     return episodeMetrics
       .filter((metric: EpisodeMetricsModel) => metric.seriesId === filter.podcastSeriesId &&
       filter.page === metric.page &&
-      metric[metricsProperty] &&
-      filterMetricsByDate(filter.beginDate, filter.endDate, filter.interval, metric[metricsProperty]))
-      .map((metric: EpisodeMetricsModel) => {
-        const filteredMetric: EpisodeMetricsModel = {...metric};
-        filteredMetric[metricsProperty] = filterMetricsByDate(filter.beginDate, filter.endDate, filter.interval, metric[metricsProperty]);
-        return filteredMetric;
-      });
+      metric[metricsProperty]);
   } else {
     return [];
   }


### PR DESCRIPTION
stop spreading the date ranges to the beginning and end of the interval to allow users to query partial weeks and months of data