### PR TITLE
Catch castle 404s

### DIFF
--- a/src/app/downloads/downloads-table.component.html
+++ b/src/app/downloads/downloads-table.component.html
@@ -35,8 +35,8 @@
           <td>{{podcastTableData.releaseDate}}</td>
           <td>{{podcastTableData.totalForPeriod | largeNumber}}</td>
           <td>{{podcastTableData.avgPerIntervalForPeriod | largeNumber}}</td>
-          <td *ngIf="podcastTableData.allTimeDownloads">{{podcastTableData.allTimeDownloads | largeNumber}}</td>
-          <td *ngIf="!podcastTableData.allTimeDownloads"></td>
+          <td *ngIf="podcastTableData.allTimeDownloads !== undefined">{{podcastTableData.allTimeDownloads | largeNumber}}</td>
+          <td *ngIf="podcastTableData.allTimeDownloads === undefined"></td>
         </tr>
         <tr *ngFor="let episode of episodeTableData">
           <td>
@@ -50,8 +50,8 @@
           <td>{{episode.releaseDate}}</td>
           <td>{{episode.totalForPeriod | largeNumber}}</td>
           <td>{{episode.avgPerIntervalForPeriod | largeNumber}}</td>
-          <td *ngIf="episode.allTimeDownloads">{{episode.allTimeDownloads | largeNumber}}</td>
-          <td *ngIf="!episode.allTimeDownloads"></td>
+          <td *ngIf="episode.allTimeDownloads !== undefined">{{episode.allTimeDownloads | largeNumber}}</td>
+          <td *ngIf="episode.allTimeDownloads === undefined"></td>
         </tr>
       </tbody>
     </table>

--- a/src/app/ngrx/effects/castle.effects.spec.ts
+++ b/src/app/ngrx/effects/castle.effects.spec.ts
@@ -143,6 +143,22 @@ describe('CastleEffects', () => {
     expect(effects.loadAllTimeEpisodeMetrics$).toBeObservable(expected);
   });
 
+  it('should return 0 on 404s for all time episode metrics', () => {
+    castle.root.mockError('prx:episode', <any> {status: 404, message: 'this is an error'});
+    const action = {
+      type: ACTIONS.ActionTypes.CASTLE_EPISODE_ALL_TIME_METRICS_LOAD,
+      payload: { episode }
+    };
+    const success = new ACTIONS.CastleEpisodeAllTimeMetricsSuccessAction({
+      episode: episode,
+      allTimeDownloads: 0
+    });
+
+    actions$.stream = hot('-a', { a: action });
+    const expected = cold('-r', { r: success });
+    expect(effects.loadAllTimeEpisodeMetrics$).toBeObservable(expected);
+  });
+
   it('should load podcast metrics', () => {
     const action = {
       type: ACTIONS.ActionTypes.CASTLE_PODCAST_METRICS_LOAD,


### PR DESCRIPTION
Catch castle episode/podcast 404s, and return 0.  Should fix #194.

Apparently I never exported `HalHttpError` from the styleguide ... but rest assured, it has a 1st class `status` property!