### PR TITLE
fixes most recent episode link from traffic sources or demographics

### DIFF
--- a/src/app/ngrx/effects/routing.effects.spec.ts
+++ b/src/app/ngrx/effects/routing.effects.spec.ts
@@ -130,7 +130,8 @@ describe('RoutingEffects', () => {
     actions$.stream = hot('-a', { a: action });
     const expected = cold('-r', { r: null });
     expect(effects.routeSingleEpisodeCharted$).toBeObservable(expected);
-    expect(effects.routeFromNewRouterState).toHaveBeenCalledWith({episodeIds: [123], chartType: CHARTTYPE_EPISODES});
+    expect(effects.routeFromNewRouterState).toHaveBeenCalledWith(
+      {episodeIds: [123], chartType: CHARTTYPE_EPISODES, metricsType: METRICSTYPE_DOWNLOADS});
   });
 
   it('routes to single episode on a specific page', () => {
@@ -139,7 +140,8 @@ describe('RoutingEffects', () => {
     actions$.stream = hot('-a', { a: action });
     const expected = cold('-r', { r: null });
     expect(effects.routeSingleEpisodeCharted$).toBeObservable(expected);
-    expect(effects.routeFromNewRouterState).toHaveBeenCalledWith({episodeIds: [123], chartType: CHARTTYPE_EPISODES, page: 2});
+    expect(effects.routeFromNewRouterState).toHaveBeenCalledWith(
+      {episodeIds: [123], chartType: CHARTTYPE_EPISODES, page: 2, metricsType: METRICSTYPE_DOWNLOADS});
   });
 
   it('should route to toggle episode charted and dispatch toggle event if not charted', () => {

--- a/src/app/ngrx/effects/routing.effects.ts
+++ b/src/app/ngrx/effects/routing.effects.ts
@@ -81,10 +81,11 @@ export class RoutingEffects {
     .map((action: ACTIONS.RouteSingleEpisodeChartedAction) => action.payload)
     .switchMap((payload: ACTIONS.RouteSingleEpisodeChartedPayload) => {
       const { episodeId, chartType, page } = payload;
+      const metricsType = METRICSTYPE_DOWNLOADS;
       if (page) {
-        this.routeFromNewRouterState({episodeIds: [episodeId], chartType, page});
+        this.routeFromNewRouterState({episodeIds: [episodeId], chartType, metricsType, page});
       } else {
-        this.routeFromNewRouterState({episodeIds: [episodeId], chartType});
+        this.routeFromNewRouterState({episodeIds: [episodeId], chartType, metricsType});
       }
       this.routerState.episodeIds.filter(id => id !== episodeId).forEach(id => {
         this.store.dispatch(new ACTIONS.CastleEpisodeChartToggleAction({


### PR DESCRIPTION
Not our highest priority, but an easy fix and it really bothered me that the navigation was broken if a user started clicking around at stuff.