### PR TITLE
active menu links

### DIFF
--- a/src/app/shared/menu/date/custom-date-range-dropdown.component.css
+++ b/src/app/shared/menu/date/custom-date-range-dropdown.component.css
@@ -8,9 +8,10 @@
   margin: 0px;
 }
 
-.dropdown-content {
+.open .dropdown-content {
   margin-top: -38px;
   box-shadow: 0 0 15px -5px rgba(0,0,0,.5);
+  padding: 20px;
 }
 
 .intervals {
@@ -21,6 +22,11 @@
 }
 .intervals > button {
   max-width: 100px;
+  padding: 10px;
+  border: 1px solid transparent;
+}
+.intervals > button.btn-link:hover {
+  background-color: #ddd;
 }
 
 .ranges {

--- a/src/app/shared/menu/date/standard-date-range-dropdown.component.ts
+++ b/src/app/shared/menu/date/standard-date-range-dropdown.component.ts
@@ -44,6 +44,7 @@ export class StandardDateRangeDropdownComponent {
   onStandardRangeChange(standardRange: string) {
     this.googleAnalyticsEvent('standard-date', standardRange);
     this.store.dispatch(new RouteStandardRangeAction({standardRange}));
+    this.toggleOpen();
   }
 
   onCustom() {

--- a/src/app/shared/menu/dropdown.css
+++ b/src/app/shared/menu/dropdown.css
@@ -42,7 +42,7 @@
   box-shadow: 0 5px 15px -5px rgba(0,0,0,.5);
 }
 .open .dropdown-content {
-  padding: 20px;
+  padding: 20px 0;
   max-height: initial;
   overflow-y: auto;
 }
@@ -54,6 +54,16 @@
 
 .dropdown-content >>> li {
   white-space: nowrap;
+}
+
+.dropdown-content >>> li .btn-link {
+  width: 100%;
+  text-align: left;
+  padding: 5px 20px;
+}
+
+.dropdown-content >>> li .btn-link:hover, .dropdown-content >>> li .btn-link:focus, .dropdown-content >>> li .btn-link.active {
+  background-color: #ddd;
 }
 
 .overlay {

--- a/src/app/shared/menu/interval-dropdown.component.css
+++ b/src/app/shared/menu/interval-dropdown.component.css
@@ -3,14 +3,8 @@
   border-right: 0px;
 }
 
-.dropdown-content {
+.open .dropdown-content {
   right: auto;
   left: 0;
-}
-
-li {
-  margin-top: 10px;
-}
-li:first-child {
-  margin-top: 0px;
+  padding: 10px 0;
 }

--- a/src/app/shared/menu/interval-dropdown.component.ts
+++ b/src/app/shared/menu/interval-dropdown.component.ts
@@ -62,5 +62,6 @@ export class IntervalDropdownComponent implements OnChanges {
     if (interval && interval !== this.routerState.interval) {
       this.store.dispatch(new RouteIntervalAction({interval}));
     }
+    this.toggleOpen();
   }
 }

--- a/src/app/shared/nav/nav-menu.component.css
+++ b/src/app/shared/nav/nav-menu.component.css
@@ -24,4 +24,5 @@ a {
 }
 a:hover, a:focus, a.active {
   background-color: #ddd;
+  color: #2b7187;
 }


### PR DESCRIPTION
I don't feel like we're quite there yet with well defined styles for menu interactions, but hopefully this is better. For example, I think we would say the backgrounds in this pop up menu are inconsistent, but using the datepicker grey for menu backgrounds would make them the same as the app background. I'm not sure that's what we want either.
<img width="648" alt="screen shot 2018-02-14 at 1 13 00 pm" src="https://user-images.githubusercontent.com/2250413/36223326-ab141272-1189-11e8-9fab-4341690d0cf9.png">
