### PR TITLE
use minY=0 on episodes chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Enter in the client id in `.env`, setting `AUTH_CLIENT_ID` to the value from abo
 
 ## Local Install
 
-Make sure you're running the node version in `.nvmrc`, and you're off!
+Make sure you're running the node version in `.nvmrc`, and you're off!!
 
 ``` sh
 # install dependencies (https://yarnpkg.com/en/docs/install)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "intl": "^1.2.5",
     "jasmine-marbles": "^0.2.0",
     "moment": "^2.18.1",
-    "ngx-prx-styleguide": "0.0.29",
+    "ngx-prx-styleguide": "0.0.33",
     "prx-ng-serve": "^0.0.3",
     "rxjs": "^5.4.1",
     "tinycolor2": "^1.4.1",

--- a/src/app/downloads/downloads-chart.component.ts
+++ b/src/app/downloads/downloads-chart.component.ts
@@ -16,7 +16,7 @@ import { largeNumberFormat } from '../shared/pipes/large-number.pipe';
   selector: 'metrics-downloads-chart',
   template: `
     <prx-timeseries-chart *ngIf="chartData" [type]="chartType" [stacked]="stacked" [datasets]="chartData"
-                          [formatX]="dateFormat()" [formatY]="largeNumberFormat"
+                          [formatX]="dateFormat()" [formatY]="largeNumberFormat" [minY]="minY"
                           [showPoints]="showPoints" [strokeWidth]="strokeWidth"
                           [pointRadius]="pointRadius" [pointRadiusOnHover]="pointRadiusOnHover">
     </prx-timeseries-chart>
@@ -220,6 +220,12 @@ export class DownloadsChartComponent implements OnDestroy {
         return 3.25;
       case CHARTTYPE_STACKED:
         return 1;
+    }
+  }
+
+  get minY(): number {
+    if (this.routerState.chartType === CHARTTYPE_EPISODES) {
+      return 0;
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3662,9 +3662,9 @@ newrelic@^2.4.2:
   optionalDependencies:
     "@newrelic/native-metrics" "^2.1.0"
 
-ngx-prx-styleguide@0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-0.0.29.tgz#17fe9489f820ca40109f95b4b324ebd915387275"
+ngx-prx-styleguide@0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-0.0.33.tgz#49a2580c07297066e6f3877c2406d291ab300857"
   dependencies:
     angular-2-dropdown-multiselect "^1.5.4"
     c3 "^0.4.11"


### PR DESCRIPTION
Except for the multiline chart where we were sometimes seeing a negative y axis when there was a lot of zeroes, it seemed best to let C3 make the decisions about the y axis.