### PR TITLE
removes redundant instanceof checks

### DIFF
--- a/src/app/ngrx/actions/cms.action.creator.ts
+++ b/src/app/ngrx/actions/cms.action.creator.ts
@@ -4,6 +4,8 @@ import { AccountModel, PodcastModel, EpisodeModel } from '../';
 
 export class CmsAccountAction implements Action {
   readonly type = ActionTypes.CMS_ACCOUNT;
+
+  constructor(public payload = {}) {}
 }
 
 export interface CmsAccountSuccessPayload {
@@ -22,6 +24,8 @@ export class CmsAccountFailureAction implements Action {
 
 export class CmsPodcastsAction implements Action {
   readonly type = ActionTypes.CMS_PODCASTS;
+
+  constructor(public payload = {}) {}
 }
 
 export interface CmsPodcastsSuccessPayload {

--- a/src/app/ngrx/actions/router.action.creator.ts
+++ b/src/app/ngrx/actions/router.action.creator.ts
@@ -99,7 +99,7 @@ export interface RouteAdvancedRangePayload {
 export class RouteAdvancedRangeAction implements Action {
   readonly type = ActionTypes.ROUTE_ADVANCED_RANGE;
 
-  constructor(public payload: any) {}
+  constructor(public payload: RouteAdvancedRangePayload) {}
 }
 
 export interface RouteEpisodePagePayload {

--- a/src/app/ngrx/reducers/account.reducer.ts
+++ b/src/app/ngrx/reducers/account.reducer.ts
@@ -34,26 +34,21 @@ export function AccountReducer(state: AccountState = initialState, action: AllAc
         loaded: false
       };
     }
-    case ActionTypes.CMS_ACCOUNT_SUCCESS:
-      if (action instanceof CmsAccountSuccessAction) {
-        return {
-          entity: action.payload.account,
-          loading: false,
-          loaded: true
-        };
-      }
-      break;
+    case ActionTypes.CMS_ACCOUNT_SUCCESS: {
+      return {
+        entity: action.payload.account,
+        loading: false,
+        loaded: true
+      };
+    }
     case ActionTypes.CMS_ACCOUNT_FAILURE: {
-      if (action instanceof CmsAccountFailureAction) {
-        return {
-          ...state,
-          error: action.payload.error,
-          entity: null,
-          loading: false,
-          loaded: false
-        };
-      }
-      break;
+      return {
+        ...state,
+        error: action.payload.error,
+        entity: null,
+        loading: false,
+        loaded: false
+      };
     }
   }
   return state;

--- a/src/app/ngrx/reducers/episode-metrics.reducer.ts
+++ b/src/app/ngrx/reducers/episode-metrics.reducer.ts
@@ -24,56 +24,50 @@ const episodeIndex = (state: EpisodeMetricsModel[], id: number, seriesId: number
 
 export function EpisodeMetricsReducer(state: EpisodeMetricsModel[] = initialState, action: ACTIONS.AllActions) {
   switch (action.type) {
-    case ACTIONS.ActionTypes.CASTLE_EPISODE_METRICS_LOAD:
-      if (action instanceof ACTIONS.CastleEpisodeMetricsLoadAction) {
-        const { id, seriesId, guid, page } = action.payload;
-        const epIdx = episodeIndex(state, id, seriesId);
-        let episode: EpisodeMetricsModel, newState: EpisodeMetricsModel[];
-        if (epIdx > -1) {
-          episode = {...state[epIdx], id, seriesId, guid, page, loading: true, loaded: false};
-          newState = [...state.slice(0, epIdx), episode, ...state.slice(epIdx + 1)];
-        } else {
-          episode = {seriesId, id, guid, page, loading: true, loaded: false};
-          newState = [episode, ...state];
-        }
-        return newState;
+    case ACTIONS.ActionTypes.CASTLE_EPISODE_METRICS_LOAD: {
+      const {id, seriesId, guid, page} = action.payload;
+      const epIdx = episodeIndex(state, id, seriesId);
+      let episode: EpisodeMetricsModel, newState: EpisodeMetricsModel[];
+      if (epIdx > -1) {
+        episode = {...state[epIdx], id, seriesId, guid, page, loading: true, loaded: false};
+        newState = [...state.slice(0, epIdx), episode, ...state.slice(epIdx + 1)];
+      } else {
+        episode = {seriesId, id, guid, page, loading: true, loaded: false};
+        newState = [episode, ...state];
       }
-      break;
-    case ACTIONS.ActionTypes.CASTLE_EPISODE_METRICS_SUCCESS:
-      if (action instanceof ACTIONS.CastleEpisodeMetricsSuccessAction) {
-        const { id, seriesId, guid, page, metricsPropertyName, metrics } = action.payload;
-        const epIdx = episodeIndex(state, id, seriesId);
-        let episode: EpisodeMetricsModel, newState: EpisodeMetricsModel[];
-        if (epIdx > -1) {
-          episode = {...state[epIdx], id, seriesId, guid, page, loading: false, loaded: true};
-          episode[metricsPropertyName] = metrics;
-          newState = [...state.slice(0, epIdx), episode, ...state.slice(epIdx + 1)];
-        } else {
-          episode = {seriesId, id, guid, page, loading: false, loaded: true};
-          episode[metricsPropertyName] = metrics;
-          newState = [episode, ...state];
-        }
-        return newState;
+      return newState;
+    }
+    case ACTIONS.ActionTypes.CASTLE_EPISODE_METRICS_SUCCESS: {
+      const {id, seriesId, guid, page, metricsPropertyName, metrics} = action.payload;
+      const epIdx = episodeIndex(state, id, seriesId);
+      let episode: EpisodeMetricsModel, newState: EpisodeMetricsModel[];
+      if (epIdx > -1) {
+        episode = {...state[epIdx], id, seriesId, guid, page, loading: false, loaded: true};
+        episode[metricsPropertyName] = metrics;
+        newState = [...state.slice(0, epIdx), episode, ...state.slice(epIdx + 1)];
+      } else {
+        episode = {seriesId, id, guid, page, loading: false, loaded: true};
+        episode[metricsPropertyName] = metrics;
+        newState = [episode, ...state];
       }
-      break;
-    case ACTIONS.ActionTypes.CASTLE_EPISODE_METRICS_FAILURE:
-      if (action instanceof ACTIONS.CastleEpisodeMetricsFailureAction) {
-        const { id, seriesId, guid, page, error } = action.payload;
-        const epIdx = episodeIndex(state, id, seriesId);
-        let episode: EpisodeMetricsModel, newState: EpisodeMetricsModel[];
-        if (epIdx > -1) {
-          episode = {...state[epIdx], id, seriesId, guid, page, error, loading: false, loaded: false};
-          newState = [...state.slice(0, epIdx), episode, ...state.slice(epIdx + 1)];
-        } else {
-          episode = {seriesId, id, guid, page, error, loading: false, loaded: false};
-          newState = [episode, ...state];
-        }
-        return newState;
+      return newState;
+    }
+    case ACTIONS.ActionTypes.CASTLE_EPISODE_METRICS_FAILURE: {
+      const {id, seriesId, guid, page, error} = action.payload;
+      const epIdx = episodeIndex(state, id, seriesId);
+      let episode: EpisodeMetricsModel, newState: EpisodeMetricsModel[];
+      if (epIdx > -1) {
+        episode = {...state[epIdx], id, seriesId, guid, page, error, loading: false, loaded: false};
+        newState = [...state.slice(0, epIdx), episode, ...state.slice(epIdx + 1)];
+      } else {
+        episode = {seriesId, id, guid, page, error, loading: false, loaded: false};
+        newState = [episode, ...state];
       }
-      break;
+      return newState;
+    }
     // TODO: #141 & #142 should remove from this state and combine with performance metrics state
     case ACTIONS.ActionTypes.CASTLE_EPISODE_PERFORMANCE_METRICS_SUCCESS: {
-      const { id, seriesId, guid, total } = action['payload'];
+      const { id, seriesId, guid, total } = action.payload;
       const epIdx = episodeIndex(state, id, seriesId);
 
       if (epIdx > -1) {
@@ -85,7 +79,7 @@ export function EpisodeMetricsReducer(state: EpisodeMetricsModel[] = initialStat
     }
       break;
     case ACTIONS.ActionTypes.CASTLE_EPISODE_PERFORMANCE_METRICS_FAILURE: {
-      const { id, seriesId, guid, error } = action['payload'];
+      const { id, seriesId, guid, error } = action.payload;
       const epIdx = episodeIndex(state, id, seriesId);
       if (epIdx > -1) {
         let episode: EpisodeMetricsModel, newState: EpisodeMetricsModel[];

--- a/src/app/ngrx/reducers/episode-performance-metrics.reducer.ts
+++ b/src/app/ngrx/reducers/episode-performance-metrics.reducer.ts
@@ -25,7 +25,7 @@ export const initialState = {
 export function EpisodePerformanceMetricsReducer(state: EpisodePerformanceMetricsState = initialState, action: ACTIONS.AllActions) {
   switch (action.type) {
     case ACTIONS.ActionTypes.CASTLE_EPISODE_PERFORMANCE_METRICS_LOAD: {
-      const {seriesId, id, guid} = action['payload'];
+      const {seriesId, id, guid} = action.payload;
       return {
         entities: {
           ...state.entities,
@@ -34,7 +34,7 @@ export function EpisodePerformanceMetricsReducer(state: EpisodePerformanceMetric
       };
     }
     case ACTIONS.ActionTypes.CASTLE_EPISODE_PERFORMANCE_METRICS_SUCCESS: {
-      const {seriesId, id, guid, total, previous7days, this7days, yesterday, today} = action['payload'];
+      const {seriesId, id, guid, total, previous7days, this7days, yesterday, today} = action.payload;
       return {
         entities: {
           ...state.entities,
@@ -43,7 +43,7 @@ export function EpisodePerformanceMetricsReducer(state: EpisodePerformanceMetric
       };
     }
     case ACTIONS.ActionTypes.CASTLE_EPISODE_PERFORMANCE_METRICS_FAILURE: {
-      const {seriesId, id, guid, error} = action['payload'];
+      const {seriesId, id, guid, error} = action.payload;
       return {
         entities: {
           ...state.entities,

--- a/src/app/ngrx/reducers/episode.reducer.ts
+++ b/src/app/ngrx/reducers/episode.reducer.ts
@@ -51,26 +51,22 @@ export function EpisodeReducer(state: EpisodeState = initialState, action: AllAc
         loaded: false
       };
     }
-    case ActionTypes.CMS_PODCAST_EPISODE_PAGE_SUCCESS:
-      if (action instanceof CmsPodcastEpisodePageSuccessAction) {
-        const entities = episodeEntities(state, action.payload.episodes);
-        return {
-          ...state,
-          entities,
-          loading: false,
-          loaded: true
-        };
-      }
-      break;
+    case ActionTypes.CMS_PODCAST_EPISODE_PAGE_SUCCESS: {
+      const entities = episodeEntities(state, action.payload.episodes);
+      return {
+        ...state,
+        entities,
+        loading: false,
+        loaded: true
+      };
+    }
     case ActionTypes.CMS_PODCAST_EPISODE_PAGE_FAILURE: {
-      if (action instanceof CmsPodcastEpisodePageFailureAction) {
-        return {
-          ...state,
-          error: action.payload.error,
-          loading: false,
-          loaded: false
-        };
-      }
+      return {
+        ...state,
+        error: action.payload.error,
+        loading: false,
+        loaded: false
+      };
     }
   }
   return state;

--- a/src/app/ngrx/reducers/podcast-metrics.reducer.ts
+++ b/src/app/ngrx/reducers/podcast-metrics.reducer.ts
@@ -26,53 +26,47 @@ const podcastIndex = (state: PodcastMetricsModel[], seriesId: number) => {
 
 export function PodcastMetricsReducer(state: PodcastMetricsModel[] = initialState, action: ACTIONS.AllActions) {
   switch (action.type) {
-    case ACTIONS.ActionTypes.CASTLE_PODCAST_METRICS_LOAD:
-      if (action instanceof ACTIONS.CastlePodcastMetricsLoadAction) {
-        const { seriesId, feederId} = action.payload;
-        const podcastIdx = podcastIndex(state, seriesId);
-        let podcast: PodcastMetricsModel, newState: PodcastMetricsModel[];
-        if (podcastIdx > -1) {
-          podcast = {...state[podcastIdx], seriesId, loading: true, loaded: false};
-          newState = [...state.slice(0, podcastIdx), podcast, ...state.slice(podcastIdx + 1)];
-        } else {
-          podcast = {seriesId, feederId, loading: true, loaded: false};
-          newState = [podcast, ...state];
-        }
-        return newState;
+    case ACTIONS.ActionTypes.CASTLE_PODCAST_METRICS_LOAD: {
+      const { seriesId, feederId} = action.payload;
+      const podcastIdx = podcastIndex(state, seriesId);
+      let podcast: PodcastMetricsModel, newState: PodcastMetricsModel[];
+      if (podcastIdx > -1) {
+        podcast = {...state[podcastIdx], seriesId, loading: true, loaded: false};
+        newState = [...state.slice(0, podcastIdx), podcast, ...state.slice(podcastIdx + 1)];
+      } else {
+        podcast = {seriesId, feederId, loading: true, loaded: false};
+        newState = [podcast, ...state];
       }
-      break;
-    case ACTIONS.ActionTypes.CASTLE_PODCAST_METRICS_SUCCESS:
-      if (action instanceof ACTIONS.CastlePodcastMetricsSuccessAction) {
-        const { seriesId, feederId, metricsPropertyName, metrics } = action.payload;
-        const podcastIdx = podcastIndex(state, seriesId);
-        let podcast: PodcastMetricsModel, newState: PodcastMetricsModel[];
-        if (podcastIdx > -1) {
-          podcast = {...state[podcastIdx], seriesId, loading: false, loaded: true};
-          podcast[metricsPropertyName] = metrics;
-          newState = [...state.slice(0, podcastIdx), podcast, ...state.slice(podcastIdx + 1)];
-        } else {
-          podcast = {seriesId, feederId, loading: false, loaded: true};
-          podcast[metricsPropertyName] = metrics;
-          newState = [podcast, ...state];
-        }
-        return newState;
+      return newState;
+    }
+    case ACTIONS.ActionTypes.CASTLE_PODCAST_METRICS_SUCCESS: {
+      const { seriesId, feederId, metricsPropertyName, metrics } = action.payload;
+      const podcastIdx = podcastIndex(state, seriesId);
+      let podcast: PodcastMetricsModel, newState: PodcastMetricsModel[];
+      if (podcastIdx > -1) {
+        podcast = {...state[podcastIdx], seriesId, loading: false, loaded: true};
+        podcast[metricsPropertyName] = metrics;
+        newState = [...state.slice(0, podcastIdx), podcast, ...state.slice(podcastIdx + 1)];
+      } else {
+        podcast = {seriesId, feederId, loading: false, loaded: true};
+        podcast[metricsPropertyName] = metrics;
+        newState = [podcast, ...state];
       }
-      break;
-    case ACTIONS.ActionTypes.CASTLE_PODCAST_METRICS_FAILURE:
-      if (action instanceof ACTIONS.CastlePodcastMetricsFailureAction) {
-        const { seriesId, feederId, error } = action.payload;
-        const podcastIdx = podcastIndex(state, seriesId);
-        let podcast: PodcastMetricsModel, newState: PodcastMetricsModel[];
-        if (podcastIdx > -1) {
-          podcast = {...state[podcastIdx], seriesId, error, loading: false, loaded: false};
-          newState = [...state.slice(0, podcastIdx), podcast, ...state.slice(podcastIdx + 1)];
-        } else {
-          podcast = {seriesId, error, loading: false, loaded: false};
-          newState = [podcast, ...state];
-        }
-        return newState;
+      return newState;
+    }
+    case ACTIONS.ActionTypes.CASTLE_PODCAST_METRICS_FAILURE: {
+      const { seriesId, feederId, error } = action.payload;
+      const podcastIdx = podcastIndex(state, seriesId);
+      let podcast: PodcastMetricsModel, newState: PodcastMetricsModel[];
+      if (podcastIdx > -1) {
+        podcast = {...state[podcastIdx], seriesId, error, loading: false, loaded: false};
+        newState = [...state.slice(0, podcastIdx), podcast, ...state.slice(podcastIdx + 1)];
+      } else {
+        podcast = {seriesId, error, loading: false, loaded: false};
+        newState = [podcast, ...state];
       }
-      break;
+      return newState;
+    }
     // TODO: #141 & #142 should remove from this state and combine with performance metrics state
     case ACTIONS.ActionTypes.CASTLE_PODCAST_PERFORMANCE_METRICS_SUCCESS: {
       const { seriesId, feederId, total } = action['payload'];

--- a/src/app/ngrx/reducers/podcast-performance-metrics.reducer.ts
+++ b/src/app/ngrx/reducers/podcast-performance-metrics.reducer.ts
@@ -24,7 +24,7 @@ export const initialState = {
 export function PodcastPerformanceMetricsReducer(state: PodcastPerformanceMetricsState = initialState, action: ACTIONS.AllActions) {
   switch (action.type) {
     case ACTIONS.ActionTypes.CASTLE_PODCAST_PERFORMANCE_METRICS_LOAD: {
-      const {seriesId, feederId} = action['payload'];
+      const {seriesId, feederId} = action.payload;
       return {
         entities: {
           ...state.entities,

--- a/src/app/ngrx/reducers/podcast.reducer.ts
+++ b/src/app/ngrx/reducers/podcast.reducer.ts
@@ -46,28 +46,23 @@ export function PodcastReducer(state: PodcastState = initialState, action: AllAc
         loaded: false
       };
     }
-    case ActionTypes.CMS_PODCASTS_SUCCESS:
-      if (action instanceof CmsPodcastsSuccessAction) {
-        const entities = podcastEntities(state, [...action.payload.podcasts]);
-        return {
-          ...state,
-          entities,
-          error: null,
-          loading: false,
-          loaded: true
-        };
-      }
-      break;
+    case ActionTypes.CMS_PODCASTS_SUCCESS: {
+      const entities = podcastEntities(state, [...action.payload.podcasts]);
+      return {
+        ...state,
+        entities,
+        error: null,
+        loading: false,
+        loaded: true
+      };
+    }
     case ActionTypes.CMS_PODCASTS_FAILURE: {
-      if (action instanceof CmsPodcastsFailureAction) {
-        return {
-          ...state,
-          error: action.payload['error'],
-          loading: false,
-          loaded: false
-        };
-      }
-      break;
+      return {
+        ...state,
+        error: action.payload['error'],
+        loading: false,
+        loaded: false
+      };
     }
   }
   return state;

--- a/src/app/ngrx/reducers/recent-episode.reducer.ts
+++ b/src/app/ngrx/reducers/recent-episode.reducer.ts
@@ -5,7 +5,6 @@ import {
   AllActions
 } from '../actions';
 import { EpisodeModel } from './episode.reducer';
-import { HalDoc } from 'ngx-prx-styleguide';
 
 interface RecentEpisodeLookup {
   [seriesId: number]: EpisodeModel;
@@ -37,26 +36,22 @@ export function RecentEpisodeReducer(state: RecentEpisodeState = initialState, a
         loaded: false
       };
     }
-    case ActionTypes.CMS_RECENT_EPISODE_SUCCESS:
-      if (action instanceof CmsRecentEpisodeSuccessAction) {
-        const entities = recentEpisodeEntities(state, action.payload.episode);
-        return {
-          ...state,
-          entities,
-          loading: false,
-          loaded: true
-        };
-      }
-      break;
+    case ActionTypes.CMS_RECENT_EPISODE_SUCCESS: {
+      const entities = recentEpisodeEntities(state, action.payload.episode);
+      return {
+        ...state,
+        entities,
+        loading: false,
+        loaded: true
+      };
+    }
     case ActionTypes.CMS_RECENT_EPISODE_FAILURE: {
-      if (action instanceof CmsRecentEpisodeFailureAction) {
-        return {
-          ...state,
-          error: action.payload.error,
-          loading: false,
-          loaded: false
-        };
-      }
+      return {
+        ...state,
+        error: action.payload.error,
+        loading: false,
+        loaded: false
+      };
     }
   }
   return state;

--- a/src/app/ngrx/reducers/router.reducer.ts
+++ b/src/app/ngrx/reducers/router.reducer.ts
@@ -1,5 +1,4 @@
 import { ActionTypes, CustomRouterNavigationAction } from '../actions';
-import { isPodcastChanged } from '../../shared/util/filter.util';
 import { RouterModel } from './models';
 
 const initialState = {};


### PR DESCRIPTION
All actions must have a payload if you want to use the discriminated union pattern (https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions). Seems kinda obvious now that I fixed it.