### PR TITLE
Fix for dup episode titles and episode metrics "loaded"

### DIFF
--- a/src/app/ngrx/actions/index.ts
+++ b/src/app/ngrx/actions/index.ts
@@ -1,12 +1,26 @@
 import { RouterNavigationAction } from '@ngrx/router-store';
 import { CmsAccountAction, CmsAccountSuccessAction, CmsAccountFailureAction } from './cms.action.creator';
-import { CastlePodcastPageLoadAction, CastlePodcastPageSuccessAction, CastlePodcastPageFailureAction,
-  CastleEpisodePageLoadAction, CastleEpisodePageSuccessAction, CastleEpisodePageFailureAction,
+import {
+  CastlePodcastPageLoadAction,
+  CastlePodcastPageSuccessAction,
+  CastlePodcastPageFailureAction,
+  CastleEpisodePageLoadAction,
+  CastleEpisodePageSuccessAction,
+  CastleEpisodePageFailureAction,
   CastlePodcastPerformanceMetricsLoadAction,
-  CastlePodcastPerformanceMetricsSuccessAction, CastlePodcastPerformanceMetricsFailureAction,
-  CastleEpisodePerformanceMetricsLoadAction, CastleEpisodePerformanceMetricsSuccessAction, CastleEpisodePerformanceMetricsFailureAction,
-  CastlePodcastMetricsLoadAction, CastlePodcastMetricsSuccessAction, CastlePodcastMetricsFailureAction,
-  CastleEpisodeMetricsLoadAction, CastleEpisodeMetricsSuccessAction, CastleEpisodeMetricsFailureAction } from './castle.action.creator';
+  CastlePodcastPerformanceMetricsSuccessAction,
+  CastlePodcastPerformanceMetricsFailureAction,
+  CastleEpisodePerformanceMetricsLoadAction,
+  CastleEpisodePerformanceMetricsSuccessAction,
+  CastleEpisodePerformanceMetricsFailureAction,
+  CastlePodcastMetricsLoadAction,
+  CastlePodcastMetricsSuccessAction,
+  CastlePodcastMetricsFailureAction,
+  CastleEpisodeMetricsLoadAction,
+  CastleEpisodeMetricsSuccessAction,
+  CastleEpisodeMetricsFailureAction,
+  CastlePodcastPageLoadPayload
+} from './castle.action.creator';
 import { GoogleAnalyticsEventAction } from './google-analytics.action.creator';
 import { CustomRouterNavigationAction,
   RoutePodcastAction, RouteEpisodePageAction,
@@ -54,7 +68,9 @@ export type AllActions
 export { ActionTypes } from './action.types';
 export { CmsAccountSuccessPayload, CmsAccountSuccessAction,
   CmsAccountAction, CmsAccountFailureAction } from './cms.action.creator';
-export { CastlePodcastPageLoadAction, CastlePodcastPageSuccessPayload, CastlePodcastPageSuccessAction, CastlePodcastPageFailureAction,
+export {
+  CastlePodcastPageLoadPayload, CastlePodcastPageLoadAction,
+  CastlePodcastPageSuccessPayload, CastlePodcastPageSuccessAction, CastlePodcastPageFailureAction,
   CastleEpisodePageLoadPayload, CastleEpisodePageLoadAction,
   CastleEpisodePageSuccessPayload, CastleEpisodePageSuccessAction, CastleEpisodePageFailureAction,
   CastlePodcastMetricsLoadPayload, CastlePodcastMetricsLoadAction,

--- a/src/app/ngrx/effects/castle.effects.ts
+++ b/src/app/ngrx/effects/castle.effects.ts
@@ -16,6 +16,7 @@ import { CastleService } from '../../core';
 import { Episode, RouterParams, getMetricsProperty, METRICSTYPE_DOWNLOADS,
   PODCAST_PAGE_SIZE, EPISODE_PAGE_SIZE } from '../';
 import * as localStorageUtil from '../../shared/util/local-storage.util';
+import {CastlePodcastPageLoadPayload} from "../actions/castle.action.creator";
 
 @Injectable()
 export class CastleEffects {
@@ -34,7 +35,7 @@ export class CastleEffects {
   loadPodcastPage$: Observable<Action> = this.actions$.pipe(
     ofType(ACTIONS.ActionTypes.CASTLE_PODCAST_PAGE_LOAD),
     map((action: ACTIONS.CastlePodcastPageLoadAction) => action.payload),
-    switchMap((payload: ACTIONS.CastleEpisodePageLoadPayload) => {
+    concatMap((payload: ACTIONS.CastlePodcastPageLoadPayload) => {
       const { page, all } = payload;
       return this.castle.followItems('prx:podcasts', { page, per: PODCAST_PAGE_SIZE })
       .pipe(
@@ -82,7 +83,7 @@ export class CastleEffects {
   );
 
   // on podcast page success if loading all podcast pages and not yet finished, load next page
-  @Effect({dispatch: false})
+  @Effect()
   loadNextPodcastPage$: Observable<Action> = this.actions$.pipe(
     ofType(ACTIONS.ActionTypes.CASTLE_PODCAST_PAGE_SUCCESS),
     filter((action: ACTIONS.CastlePodcastPageSuccessAction) => {

--- a/src/app/ngrx/reducers/episode-metrics.reducer.spec.ts
+++ b/src/app/ngrx/reducers/episode-metrics.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { CastleEpisodeMetricsSuccessAction } from '../actions';
+import { CastleEpisodeMetricsSuccessAction, CastleEpisodePageSuccessAction } from '../actions';
 import { INTERVAL_DAILY, MetricsType, METRICSTYPE_DOWNLOADS, RouterParams, getMetricsProperty } from '../';
 import { EpisodeMetricsReducer } from './episode-metrics.reducer';
 import { episodes, ep0Downloads, ep1Downloads } from '../../../testing/downloads.fixtures';
@@ -55,5 +55,16 @@ describe('EpisodeMetricsReducer', () => {
       })
     );
     expect(newState.filter(p => p.podcastId === '70').length).toEqual(2);
+  });
+
+  it('should set loaded to false on episode page load if entry not already on state', () => {
+    newState = EpisodeMetricsReducer(newState,
+      new CastleEpisodePageSuccessAction({
+        page: 2,
+        episodes: episodes,
+        total: episodes.length
+      })
+    );
+    expect(newState.filter(episodeMetrics => episodeMetrics.page === 2).every(entry => !entry.loaded)).toBeTruthy();
   });
 });

--- a/src/app/ngrx/reducers/episode-metrics.reducer.ts
+++ b/src/app/ngrx/reducers/episode-metrics.reducer.ts
@@ -22,6 +22,21 @@ const episodeIndex = (state: EpisodeMetricsModel[], guid: string) => {
 
 export function EpisodeMetricsReducer(state: EpisodeMetricsModel[] = initialState, action: ACTIONS.AllActions) {
   switch (action.type) {
+    case ACTIONS.ActionTypes.CASTLE_EPISODE_PAGE_SUCCESS: {
+      // sets loaded to false on entry when episode page is loaded expecting that metrics will also be loaded
+      // (prevents loaded selector from showing prematurely when metrics load call has momentarily not yet been made)
+      const {episodes, page} = action.payload;
+      let newState = state;
+      episodes.forEach(episode => {
+        const {guid, podcastId} = episode;
+        const epIdx = episodeIndex(state, guid);
+        if (epIdx === -1) {
+          episode = {podcastId, guid, page, loaded: false};
+          newState = [episode, ...state.slice(epIdx + 1)];
+        }
+      });
+      return newState;
+    }
     case ACTIONS.ActionTypes.CASTLE_EPISODE_METRICS_LOAD: {
       const {podcastId, guid, page} = action.payload;
       const epIdx = episodeIndex(state, guid);

--- a/src/app/ngrx/reducers/episode-metrics.reducer.ts
+++ b/src/app/ngrx/reducers/episode-metrics.reducer.ts
@@ -32,7 +32,7 @@ export function EpisodeMetricsReducer(state: EpisodeMetricsModel[] = initialStat
         const epIdx = episodeIndex(state, guid);
         if (epIdx === -1) {
           episode = {podcastId, guid, page, loaded: false};
-          newState = [episode, ...state.slice(epIdx + 1)];
+          newState = [episode, ...state];
         }
       });
       return newState;

--- a/src/app/ngrx/reducers/episode.reducer.spec.ts
+++ b/src/app/ngrx/reducers/episode.reducer.spec.ts
@@ -27,9 +27,21 @@ describe('Episode Reducer', () => {
   it('should set episode entities and pagesLoaded on episode page success', () => {
     const newState = reducer(initialState,
       new ACTIONS.CastleEpisodePageSuccessAction({page: 1, total: episodes.length, all: true, episodes}));
-    expect(newState.entities[episodes[0].guid]).toEqual(episodes[0]);
+    // @ts-ignore using upsert adds 'id' property to entity, seems like ngrx/entity v6 gets rid of this
+    expect(newState.entities[episodes[0].guid]).toEqual({...episodes[0], id: episodes[0].guid});
     expect(newState.pagesLoaded.indexOf(1)).not.toBe(-1);
     expect(newState.pagesLoading.indexOf(1)).toBe(-1);
+  });
+
+  it('should update an episode entity if it was already on the state', () => {
+    let newState = reducer(initialState,
+      new ACTIONS.CastleEpisodePageSuccessAction({page: 1, total: episodes.length, all: true, episodes}));
+    // @ts-ignore using upsert adds 'id' property to entity, seems like ngrx/entity v6 gets rid of this
+    expect(newState.entities[episodes[1].guid]).toEqual({...episodes[1], id: episodes[1].guid});
+    newState = reducer(initialState,
+      new ACTIONS.CastleEpisodePageSuccessAction({page: 1, total: episodes.length, all: true,
+        episodes: [episodes[0], {...episodes[1], title: 'an updated title'}]}));
+    expect(newState.entities[episodes[1].guid].title).toEqual('an updated title');
   });
 
   it('should set error on failure', () => {

--- a/src/app/ngrx/reducers/episode.reducer.ts
+++ b/src/app/ngrx/reducers/episode.reducer.ts
@@ -60,7 +60,9 @@ export function reducer(
     }
     case ActionTypes.CASTLE_EPISODE_PAGE_SUCCESS: {
       return {
-        ...adapter.addMany(action.payload.episodes, state),
+        ...adapter.upsertMany(action.payload.episodes.map(episode => {
+          return {id: episode.guid, changes: episode};
+        }), state),
         pagesLoaded: addToArray(state.pagesLoaded, action.payload.page),
         pagesLoading: removeFromArray(state.pagesLoading, action.payload.page),
         total: action.payload.page === 1 || !state.total ? action.payload.total : state.total

--- a/src/app/ngrx/reducers/podcast.reducer.spec.ts
+++ b/src/app/ngrx/reducers/podcast.reducer.spec.ts
@@ -13,10 +13,19 @@ describe('Podcast Reducer', () => {
     });
   });
 
-  it('should set podcast entities podcast page success', () => {
+  it('should set podcast entities on podcast page success', () => {
     const newState = reducer(initialState,
       new ACTIONS.CastlePodcastPageSuccessAction({page: 1, total: 1, all: true, podcasts: [podcast]}));
     expect(newState.entities[podcast.id]).toEqual(podcast);
+  });
+
+  it('should update a podcast entity if it was already on the state', () => {
+    let newState = reducer(initialState,
+      new ACTIONS.CastlePodcastPageSuccessAction({page: 1, total: 1, all: true, podcasts: [podcast]}));
+    expect(newState.entities[podcast.id]).toEqual(podcast);
+    newState = reducer(initialState,
+      new ACTIONS.CastlePodcastPageSuccessAction({page: 1, total: 1, all: true, podcasts: [{...podcast, title: 'an updated title'}]}));
+    expect(newState.entities[podcast.id].title).toEqual('an updated title');
   });
 
   it('should set error on failure', () => {

--- a/src/app/ngrx/reducers/podcast.reducer.ts
+++ b/src/app/ngrx/reducers/podcast.reducer.ts
@@ -25,7 +25,12 @@ export function reducer(
 ): State {
   switch (action.type) {
     case ActionTypes.CASTLE_PODCAST_PAGE_SUCCESS: {
-      return adapter.addMany(action.payload.podcasts, state);
+      return adapter.upsertMany(action.payload.podcasts.map(podcast => {
+        return {
+          id: podcast.id,
+          changes: podcast
+        };
+      }), state);
     }
     case ActionTypes.CASTLE_PODCAST_PAGE_FAILURE: {
       return { ...state, error: action.payload.error};

--- a/src/app/ngrx/reducers/selectors/downloads-chart.selectors.spec.ts
+++ b/src/app/ngrx/reducers/selectors/downloads-chart.selectors.spec.ts
@@ -162,6 +162,19 @@ describe('Downloads Chart Selectors', () => {
       store.dispatch(new ACTIONS.ChartToggleEpisodeAction({guid: episodes[0].guid, charted: false}));
       expect(result.length).toEqual(episodes.length - 1);
     });
+
+    it('should add first part of guid string to non unique episode titles', () => {
+      store.dispatch(new ACTIONS.CastleEpisodePageSuccessAction({
+        episodes: [
+          episodes[0],
+          {...episodes[1], title: episodes[0].title, guid: episodes[0].guid + '-' + episodes[0].guid}
+        ],
+        page: 1,
+        total: episodes.length
+      }));
+
+      expect(result[0].label.indexOf(episodes[0].guid.split('-')[0].substr(0, 10))).toBeGreaterThan(-1);
+    });
   });
 
 });

--- a/src/app/ngrx/reducers/selectors/downloads-chart.selectors.ts
+++ b/src/app/ngrx/reducers/selectors/downloads-chart.selectors.ts
@@ -40,10 +40,12 @@ export const selectDownloadChartMetrics = createSelector(
       if (episodes.length && episodeMetrics.length) {
         chartedEpisodeMetrics = episodes
           .sort((a: Episode, b: Episode) => b.publishedAt.valueOf() - a.publishedAt.valueOf())
-          .map((episode: Episode, idx) => {
+          .map((episode: Episode, idx, self) => {
+            const uniqueLabel = self.filter(e => e.title === episode.title).length > 1 ?
+              episode.title + ' ' + episode.guid.split('-')[0].substr(0, 10) :  episode.title;
             return {
               guid: episode.guid,
-              label: episode.title,
+              label: uniqueLabel,
               color: getColor(idx)
             };
           })

--- a/src/app/ngrx/reducers/selectors/episode-metrics.selectors.ts
+++ b/src/app/ngrx/reducers/selectors/episode-metrics.selectors.ts
@@ -20,3 +20,9 @@ export const selectRoutedEpisodePageMetrics = createSelector(selectPodcastRoute,
   (podcastId: string, page: number, metrics: EpisodeMetricsModel[]) => {
     return metrics.filter((metric: EpisodeMetricsModel) => metric.podcastId === podcastId && page === metric.page);
 });
+export const selectRoutedEpisodePageMetricsLoaded = createSelector(selectPodcastRoute, selectPageRoute, selectEpisodeMetrics,
+  (podcastId: string, page: number, metrics: EpisodeMetricsModel[]) => {
+    return metrics
+      .filter((metric: EpisodeMetricsModel) => metric.podcastId === podcastId && page === metric.page)
+      .every((m: EpisodeMetricsModel) => m.loaded || m.loaded === undefined);
+  });

--- a/src/app/ngrx/reducers/selectors/loaded.selectors.ts
+++ b/src/app/ngrx/reducers/selectors/loaded.selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from '@ngrx/store';
 import { selectRoutedPageLoaded } from './episode.selectors';
 import { selectRoutedPodcastLoaded } from './podcast.selectors';
-import { selectEpisodeMetricsLoaded } from './episode-metrics.selectors';
+import { selectRoutedEpisodePageMetricsLoaded } from './episode-metrics.selectors';
 import { selectPodcastMetricsLoaded } from './podcast-metrics.selectors';
 
 export const selectCatalogLoaded = createSelector(
@@ -11,7 +11,7 @@ export const selectCatalogLoaded = createSelector(
     return episodes && podcasts;
   });
 export const selectMetricsLoaded = createSelector(
-  selectEpisodeMetricsLoaded,
+  selectRoutedEpisodePageMetricsLoaded,
   selectPodcastMetricsLoaded,
   (episodeMetrics, podcastMetrics) => {
     return episodeMetrics && podcastMetrics;


### PR DESCRIPTION
* Fixes the issue with duplicate episode titles (Showcase is a good example.) The chart maps the labels into an object, so the labels need to be unique.
* Fixes another issue with "loaded" when flipping between pages on the episode chart. There is a brief flash of a placeholder from components that should not display until data is loaded. In order to make "loading" stick while other data loading is in progress, set the episode metrics loaded to false when an episode page is loaded. Expecting that the download data will be need to be loaded into the state before displaying any components trying to use it.