### PR TITLE
ticks for hourly charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ puma-dev is used for ssl support, and on MacOS you will also need to accept the 
 * Open https://metrics.prx.dev in Safari
 * The certificate gets incorrectly saved in Keychain Access under login -> Certificates. Move the certificate to System -> Certificates.
 
+Warning: puma-dev may not be compatible with your docker proxy
+
 ## Docker Install
 
  Or if you really want to, you can develop via docker-compose.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "intl": "^1.2.5",
     "jasmine-marbles": "^0.2.0",
     "moment": "^2.18.1",
-    "ngx-prx-styleguide": "1.3.0",
+    "ngx-prx-styleguide": "1.4.0",
     "prx-ng-serve": "^0.0.3",
     "rxjs": "^5.5.2",
     "tinycolor2": "^1.4.1",

--- a/src/app/downloads/downloads-chart-presentation.component.ts
+++ b/src/app/downloads/downloads-chart-presentation.component.ts
@@ -12,7 +12,8 @@ import { largeNumberFormat } from '../shared/pipes/large-number.pipe';
     <prx-timeseries-chart *ngIf="chartData" [type]="chartType" [stacked]="stacked" [datasets]="chartData"
                           [formatX]="dateFormat()" [formatY]="largeNumberFormat" [minY]="minY"
                           [showPoints]="showPoints" [strokeWidth]="strokeWidth"
-                          [pointRadius]="pointRadius" [pointRadiusOnHover]="pointRadiusOnHover">
+                          [pointRadius]="pointRadius" [pointRadiusOnHover]="pointRadiusOnHover"
+                          [maxTicks]="maxTicks">
     </prx-timeseries-chart>
     <div class="placeholder" *ngIf="!chartData">
       You have no data selected. Would you like to view the <button class="btn-link" (click)="placeholder.emit()">Podcast chart</button>?
@@ -107,6 +108,12 @@ export class DownloadsChartPresentationComponent {
   get minY(): number {
     if (this.routerParams.chartType === CHARTTYPE_EPISODES) {
       return 0;
+    }
+  }
+
+  get maxTicks(): number {
+    if (this.routerParams.interval === INTERVAL_HOURLY) {
+      return 48;
     }
   }
 }

--- a/src/app/shared/util/date/date.format.spec.ts
+++ b/src/app/shared/util/date/date.format.spec.ts
@@ -18,6 +18,7 @@ describe('date format', () => {
 
   it('should format hourly dates in local timezone', () => {
     const date = new Date();
+    date.setMinutes(0);
     const dateString = dateFormat.hourly(date);
     let hours;
     if (date.getHours() === 0) {
@@ -26,6 +27,22 @@ describe('date format', () => {
       hours = date.getHours() % 12;
     } else {
       hours = date.getHours();
+    }
+    expect(parseInt(dateString.slice(dateString.indexOf(', ') + 1), 10)).toEqual(hours);
+  });
+
+  it('should round hourly date format to the nearest hour', () => {
+    const date = new Date();
+    date.setMinutes(39);
+    const dateString = dateFormat.hourly(date);
+    let hours;
+    const roundedHours = date.getMinutes() > 30 ? (date.getHours() + 1) % 24 : date.getHours();
+    if (roundedHours === 0) {
+      hours = 12;
+    } else if (roundedHours > 12) {
+      hours = roundedHours % 12;
+    } else {
+      hours = roundedHours;
     }
     expect(parseInt(dateString.slice(dateString.indexOf(', ') + 1), 10)).toEqual(hours);
   });

--- a/src/app/shared/util/date/date.format.ts
+++ b/src/app/shared/util/date/date.format.ts
@@ -25,5 +25,7 @@ export const monthYear = (date: Date): string => {
 };
 
 export const hourly = (date: Date): string => {
-  return moment(date).format('MMM D, h:mm A');
+  return date.getMinutes() < 30 ?
+    moment(date).format('MMM D, h:00 A') :
+    moment(date).add(1, 'hours').format('MMM D, h:00 A');
 };


### PR DESCRIPTION
#298 and #307 
Hourly charts will use the new maxTicks setting on timeseries charts to limit the amount of ticks shown to prevent issues such as those shown in #229 

Depends on [PR for styleguide v1.4.0](https://github.com/PRX/styleguide.prx.org/pull/120)