### PR TITLE
Fix Drop-Day tab days-picker

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,10 +6,16 @@ env:
     PRX_ECR_CONFIG_PARAMETERS: "MetricsEcrImageTag"
   parameter-store:
     CODECOV_TOKEN: "/prx/test/metrics.prx.org/CODECOV_TOKEN"
+    DOCKERHUB_USERNAME: '/prx/DOCKERHUB_USERNAME'
+    DOCKERHUB_PASSWORD: '/prx/DOCKERHUB_PASSWORD'
 phases:
   install:
     runtime-versions:
       docker: 18
+  pre_build:
+    commands:
+      - echo Logging in to Docker Hub...
+      - echo $DOCKERHUB_PASSWORD | docker login --username $DOCKERHUB_USERNAME --password-stdin
   build:
     commands:
       - "cd $(ls -d */|head -n 1)"

--- a/src/app/ngrx/effects/routing.effects.ts
+++ b/src/app/ngrx/effects/routing.effects.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@angular/core';
-import { map, switchMap } from 'rxjs/operators';
-import { of, Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { of } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { routerNavigationAction } from '@ngrx/router-store';
-import { Actions, Effect, ofType, createEffect } from '@ngrx/effects';
-import { ActionTypes } from '../actions';
+import { Actions, ofType, createEffect } from '@ngrx/effects';
 import * as ACTIONS from '../actions';
 import * as dateUtil from '@app/shared/util/date';
 import { RoutingService } from '@app/core/routing/routing.service';
@@ -145,7 +144,6 @@ export class RoutingEffects {
     { dispatch: false }
   );
 
-  @Effect()
   routeDays$ = createEffect(
     () =>
       this.actions$.pipe(


### PR DESCRIPTION
Closes #431.

Looks like back in #428 (and b0a69eba09755d063b35841000f452a01aa669eb) ngrx was upgraded from 8.6 -> 9.2.  Which [deprecated the @Effect decorator](https://ngrx.io/guide/migration/v9#ngrxeffects).

One decorator was missed apparently (only one in the codebase).  And using both the decorator `createEffect` does weird things - was complaining about the null returned by the effect having no `type`?  (I think?).

In any case, removing the decorator fixes it.